### PR TITLE
Include OpenAPI validation errors in responses

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -63,7 +63,10 @@ async function createHttpServer() {
   // Sorry - app.use checks arity
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
-    if (err.status) {
+    if (err.errors) {
+      // openapi validation
+      res.status(err.status).send(err.errors)
+    } else if (err.status) {
       res.status(err.status).send({ error: err.status === 401 ? 'Unauthorised' : err.message })
     } else {
       logger.error('Fallback Error %j', err.stack)

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.2.0'
+appVersion: '1.2.1'
 description: A Helm chart for inteli-api
-version: '1.2.0'
+version: '1.2.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -6,7 +6,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.2.0'
+  tag: 'v1.2.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Bug: `400` responses for OpenAPI validation were missing the actual errors e.g. 
```
    {
        "path": "imageAttachmentId",
        "errorCode": "minLength.openapi.requestValidation",
        "message": "must NOT have fewer than 36 characters",
        "location": "body"
    }
```

Solution: includes `err.errors` in the response
