### PR TITLE
Add identity service docker config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,5 +11,52 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=inteli
+  
+  postgres-dscp:
+    image: postgres:14.1-alpine
+    ports:
+      - 5433:5432
+    volumes:
+      - dscp-storage:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=dscp
+
+  dscp-identity-service:
+    image: ghcr.io/digicatapult/dscp-identity-service:latest
+    command: /bin/sh -c "
+      sleep 60 &&
+      node app/index.js"
+    ports:
+      - 3001:3001
+    environment:
+      - PORT=3001
+      # - USER_URI=3001
+      - API_HOST=dscp-node
+      - AUTH_JWKS_URI=https://inteli.eu.auth0.com/.well-known/jwks.json
+      - AUTH_AUDIENCE=inteli-dev
+      - AUTH_ISSUER=https://inteli.eu.auth0.com/
+      - AUTH_TOKEN_URL=https://inteli.eu.auth0.com/oauth/token
+      - DB_HOST=postgres-dscp
+      - DB_PORT=5432
+      - DB_NAME=dscp
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=postgres
+
+  dscp-node:
+    image: ghcr.io/digicatapult/dscp-node:latest
+    command:
+      --base-path /data/
+      --dev
+      --unsafe-ws-external
+      --unsafe-rpc-external
+      --rpc-cors all
+    ports:
+      - 30333:30333
+      - 9944:9944
+      - 9933:9933
+    restart: on-failure
 volumes:
   data-storage:
+  dscp-storage:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     image: ghcr.io/digicatapult/dscp-identity-service:latest
     command: /bin/sh -c "
       sleep 60 &&
+      npx knex migrate:latest &&
       node app/index.js"
     ports:
       - 3001:3001

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.6.0'
+appVersion: '1.7.0'
 description: A Helm chart for inteli-api
-version: '1.6.0'
+version: '1.7.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -6,7 +6,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.6.0'
+  tag: 'v1.7.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
**Problem**
We'd like to use identity service for some validation, so we need a dev instance to test with.

**Solution**
Define a development instance in the docker compose config, as well as associated dependencies, so that we can use it for testing and development of inteli-api