### PR TITLE
Bug/add missing helm envs

### DIFF
--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.6.0'
+appVersion: '1.6.1'
 description: A Helm chart for inteli-api
-version: '1.6.0'
+version: '1.6.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/templates/configmap.yaml
+++ b/helm/inteli-api/templates/configmap.yaml
@@ -10,3 +10,7 @@ data:
   dbHost: {{ include "inteli-api.postgresql.fullname" . }}
   dbPort: {{ .Values.config.dbPort | quote }}
   dbName: {{ .Values.config.dbName }}
+  authJwksUri: {{ .Values.config.auth.jwksUri }}
+  authAudience: {{ .Values.config.auth.audience }}
+  authIssuer: {{ .Values.config.auth.issuer }}
+  authTokenUrl: {{ .Values.config.auth.tokenUrl }}

--- a/helm/inteli-api/templates/deployment.yaml
+++ b/helm/inteli-api/templates/deployment.yaml
@@ -95,3 +95,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-secret
                   key: dbPassword
+            - name: AUTH_JWKS_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: authJwksUri
+            - name: AUTH_AUDIENCE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: authAudience
+            - name: AUTH_ISSUER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: authIssuer
+            - name: AUTH_TOKEN_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: authTokenUrl

--- a/helm/inteli-api/templates/deployment.yaml
+++ b/helm/inteli-api/templates/deployment.yaml
@@ -98,20 +98,20 @@ spec:
             - name: AUTH_JWKS_URI
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "dscp-api.fullname" . }}-config
+                  name: {{ include "inteli-api.fullname" . }}-config
                   key: authJwksUri
             - name: AUTH_AUDIENCE
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "dscp-api.fullname" . }}-config
+                  name: {{ include "inteli-api.fullname" . }}-config
                   key: authAudience
             - name: AUTH_ISSUER
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "dscp-api.fullname" . }}-config
+                  name: {{ include "inteli-api.fullname" . }}-config
                   key: authIssuer
             - name: AUTH_TOKEN_URL
               valueFrom:
                 configMapKeyRef:
-                  name: {{ include "dscp-api.fullname" . }}-config
+                  name: {{ include "inteli-api.fullname" . }}-config
                   key: authTokenUrl

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -3,6 +3,12 @@ config:
   logLevel: info
   dbName: inteli
   dbPort: 5432
+  auth:
+    jwksUri: https://inteli.eu.auth0.com/.well-known/jwks.json
+    audience: inteli-dev
+    issuer: https://inteli.eu.auth0.com/
+    tokenUrl: https://inteli.eu.auth0.com/oauth/token
+
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -12,7 +12,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.6.0'
+  tag: 'v1.6.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Problem:
https://github.com/digicatapult/inteli-api/pull/10 missed adding the new Auth0 envs to `helm/`, making the `helm-test` workflow fail sometimes

Solution:
Add the missing envs
