### PR TITLE
Support JSON attachment in POST /attachment

### DIFF
--- a/app/api-v1/services/attachmentService.js
+++ b/app/api-v1/services/attachmentService.js
@@ -2,16 +2,22 @@ const fs = require('fs')
 const { insertAttachment } = require('../../db')
 const { HttpResponseError } = require('../../utils/errors')
 
-const createAttachment = async (file) => {
+const createAttachmentFromFile = async (file) => {
   return new Promise((resolve) => {
     fs.readFile(file.path, async (err, data) => {
       if (err) throw new HttpResponseError({ code: 500, message: err.message, service: 'attachment' })
-      const attachment = await insertAttachment(file.originalname, data)
+      const attachment = await createAttachment(file.originalname, data)
       resolve(attachment)
     })
   })
 }
 
+const createAttachment = async (name, buffer) => {
+  const attachment = await insertAttachment(name, buffer)
+  return attachment
+}
+
 module.exports = {
   createAttachment,
+  createAttachmentFromFile,
 }

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -39,6 +39,8 @@ const handleErrors = (err, req, res, next) => {
   // multer errors
   else if (err.code) {
     res.status(400).send(err.message)
+  } else if (err.status) {
+    res.status(err.status).send(err.expose ? err.message : 'Unknown error')
   } else {
     logger.error('Fallback Error %j', err.stack)
     res.status(500).send('Fatal error!')

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.7.1'
+appVersion: '1.8.0'
 description: A Helm chart for inteli-api
-version: '1.7.1'
+version: '1.8.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -14,7 +14,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.7.1'
+  tag: 'v1.8.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -77,10 +77,27 @@ async function postAttachmentNoFile({ app }, token) {
     })
 }
 
+async function postAttachmentJSON({ app }, body, token) {
+  return request(app)
+    .post(`/${API_MAJOR_VERSION}/attachment`)
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json')
+    .set('Authorization', `Bearer ${token}`)
+    .send(body)
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`postAttachmentErr ${err}`)
+      return err
+    })
+}
+
 module.exports = {
   apiDocs,
   healthCheck,
   postRecipeRoute,
   postAttachment,
   postAttachmentNoFile,
+  postAttachmentJSON,
 }

--- a/test/integration/attachment.test.js
+++ b/test/integration/attachment.test.js
@@ -3,7 +3,7 @@ const { describe, before, it, after } = require('mocha')
 const { expect } = require('chai')
 
 const { createHttpServer } = require('../../app/server')
-const { postAttachment, postAttachmentNoFile } = require('../helper/routeHelper')
+const { postAttachment, postAttachmentNoFile, postAttachmentJSON } = require('../helper/routeHelper')
 const { AUTH_ISSUER, AUTH_AUDIENCE, FILE_UPLOAD_SIZE_LIMIT_BYTES } = require('../../app/env')
 
 describe('attachments', function () {
@@ -47,5 +47,33 @@ describe('attachments', function () {
     const response = await postAttachmentNoFile(app, authToken)
     expect(response.status).to.equal(400)
     expect(response.error.text).to.equal('No file uploaded')
+  })
+
+  it('should return 201 - json object uploaded', async function () {
+    const attachment = { key: 'test' }
+    const response = await postAttachmentJSON(app, attachment, authToken)
+
+    expect(response.status).to.equal(201)
+    expect(response.body).to.have.property('id')
+    expect(response.body.filename).to.equal('json')
+    expect(response.body.size).to.equal(Buffer.from(JSON.stringify(attachment)).length)
+  })
+
+  it('should return 201 - json array uploaded', async function () {
+    const attachment = ['test']
+    const response = await postAttachmentJSON(app, attachment, authToken)
+
+    expect(response.status).to.equal(201)
+    expect(response.body).to.have.property('id')
+    expect(response.body.filename).to.equal('json')
+    expect(response.body.size).to.equal(Buffer.from(JSON.stringify(attachment)).length)
+  })
+
+  it('should return 400 - json string uploaded', async function () {
+    const attachment = 'test'
+    const response = await postAttachmentJSON(app, attachment, authToken)
+
+    expect(response.status).to.equal(400)
+    expect(response.error.text).to.equal('Unexpected token t in JSON at position 0')
   })
 })


### PR DESCRIPTION
Support JSON attachment in `POST` `/attachment`

Note we use `body-parser` in strict mode so only `object` and `array` values are allowed. This is documented in the spec schema

