### PR TITLE
Order with self route self

### DIFF
--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -266,11 +266,6 @@ const apiDoc = {
             type: 'string',
             maxLength: 255,
           },
-          purchaserAddress: {
-            description: 'The address of the purchaser',
-            type: 'string',
-            maxLength: 255,
-          },
           requiredBy: {
             description: 'Date and time at which the purchase-order must be completed',
             type: 'string',
@@ -295,7 +290,7 @@ const apiDoc = {
             description: 'local id of the purchase-order',
             allOf: [{ $ref: '#/components/schemas/ObjectReference' }],
           },
-          owner: {
+          purchaser: {
             description:
               'Name of the submitter of the purchase-order. This information is not stored directly on-chain',
             type: 'string',

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -261,6 +261,11 @@ const apiDoc = {
             type: 'string',
             maxLength: 255,
           },
+          // purchaserAddress: {
+          //   description: 'The address of the purchaser',
+          //   type: 'string',
+          //   maxLength: 255,
+          // },
           requiredBy: {
             description: 'Date and time at which the purchase-order must be completed',
             type: 'string',

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -261,11 +261,11 @@ const apiDoc = {
             type: 'string',
             maxLength: 255,
           },
-          // purchaserAddress: {
-          //   description: 'The address of the purchaser',
-          //   type: 'string',
-          //   maxLength: 255,
-          // },
+          purchaserAddress: {
+            description: 'The address of the purchaser',
+            type: 'string',
+            maxLength: 255,
+          },
           requiredBy: {
             description: 'Date and time at which the purchase-order must be completed',
             type: 'string',

--- a/app/api-v1/routes/order.js
+++ b/app/api-v1/routes/order.js
@@ -6,27 +6,21 @@ module.exports = function (orderService, identityService) {
       res.status(500).json({ message: 'Not Implemented' })
     },
     POST: async function (req, res) {
-      console.log('*** *** 1 HELLO REQUEST CALLD')
-
-      const responseOne = await identityService.getMemberByAlias(req, req.body.supplier)
-      console.log('*** 1 responseOne', responseOne)
-
-      // const responseTwo = await identityService.getMemberBySelf(req.body)
-      // console.log('*** *** 1 responseTwo', responseTwo)
-      // console.log('*** 1 supplier', supplier)
-
-      const { statusCode, result } = await orderService.postOrder({
-        ...req.body,
-        supplier: '', // supplierAddress,
-        purchaserAddress: '', // supplier,
-      })
-
-      console.log('*** 1 result', result)
-
       if (!req.body) {
         throw new BadRequestError({ message: 'No body uploaded', service: 'order' })
       }
-      return res.status(statusCode).json({ ...result[0], supplier: req.body.supplier })
+
+      const response = await identityService.getMemberByAlias(req, req.body.supplier)
+
+      const selfAddress = await identityService.getMemberBySelf(req, response.address)
+
+      const { statusCode, result } = await orderService.postOrder({
+        ...req.body,
+        supplier: response.address,
+        purchaserAddress: selfAddress.alias,
+      })
+
+      return res.status(statusCode).json({ ...result[0], supplier: req.body.supplier, purchaserAddress: response })
     },
   }
 

--- a/app/api-v1/routes/order.js
+++ b/app/api-v1/routes/order.js
@@ -10,17 +10,22 @@ module.exports = function (orderService, identityService) {
         throw new BadRequestError({ message: 'No body uploaded', service: 'order' })
       }
 
-      const response = await identityService.getMemberByAlias(req, req.body.supplier)
-
-      const selfAddress = await identityService.getMemberBySelf(req, response.address)
+      const { address: supplierAddress } = await identityService.getMemberByAlias(req, req.body.supplier)
+      const selfAddress = await identityService.getMemberBySelf(req)
+      const { alias: selfAlias } = await identityService.getMemberByAlias(req, selfAddress)
 
       const { statusCode, result } = await orderService.postOrder({
         ...req.body,
-        supplier: response.address,
-        purchaserAddress: selfAddress.alias,
+        supplier: supplierAddress,
+        purchaserAddress: selfAlias,
       })
 
-      return res.status(statusCode).json({ ...result[0], supplier: req.body.supplier, purchaserAddress: response })
+      return res.status(statusCode).json({
+        id: result.id,
+        status: 'Created',
+        purchaser: selfAlias,
+        ...req.body,
+      })
     },
   }
 

--- a/app/api-v1/routes/order.js
+++ b/app/api-v1/routes/order.js
@@ -6,9 +6,23 @@ module.exports = function (orderService, identityService) {
       res.status(500).json({ message: 'Not Implemented' })
     },
     POST: async function (req, res) {
-      const { address: supplierAddress } = await identityService.getMemberByAlias(req, req.body.supplier)
+      console.log('*** *** 1 HELLO REQUEST CALLD')
 
-      const { statusCode, result } = await orderService.postOrder({ ...req.body, supplier: supplierAddress })
+      const responseOne = await identityService.getMemberByAlias(req, req.body.supplier)
+      console.log('*** 1 responseOne', responseOne)
+
+      // const responseTwo = await identityService.getMemberBySelf(req.body)
+      // console.log('*** *** 1 responseTwo', responseTwo)
+      // console.log('*** 1 supplier', supplier)
+
+      const { statusCode, result } = await orderService.postOrder({
+        ...req.body,
+        supplier: '', // supplierAddress,
+        purchaserAddress: '', // supplier,
+      })
+
+      console.log('*** 1 result', result)
+
       if (!req.body) {
         throw new BadRequestError({ message: 'No body uploaded', service: 'order' })
       }

--- a/app/api-v1/services/identityService.js
+++ b/app/api-v1/services/identityService.js
@@ -24,16 +24,12 @@ const getMemberByAlias = async (req, alias) => {
   throw new InternalError({ message: 'Internal server error' })
 }
 
-const getMemberBySelf = async (req, alias) => {
-  const response = await fetch(`${URL_PREFIX}/self/${encodeURIComponent(alias)}`, {
+const getMemberBySelf = async (req) => {
+  const response = await fetch(`${URL_PREFIX}/self`, {
     headers: {
       Authorization: `Bearer ${req.token}`,
     },
   })
-
-  if (response.status === 404) {
-    throw new BadRequestError({ message: `Self does not exist` })
-  }
 
   if (response.ok) {
     const member = await response.json()

--- a/app/api-v1/services/identityService.js
+++ b/app/api-v1/services/identityService.js
@@ -24,9 +24,29 @@ const getMemberByAlias = async (req, alias) => {
   throw new InternalError({ message: 'Internal server error' })
 }
 
+const getMemberBySelf = async (req) => {
+  const response = await fetch(`${URL_PREFIX}/self`, {
+    headers: {
+      Authorization: `Bearer ${req.token}`,
+    },
+  })
+
+  if (response.ok) {
+    const member = await response.json()
+    return member
+  }
+
+  if (response.status === 404) {
+    throw new BadRequestError({ message: `Self does not exist` })
+  }
+
+  throw new InternalError({ message: 'Internal server error' })
+}
+
 const getMemberByAddress = (...args) => getMemberByAlias(...args)
 
 module.exports = {
   getMemberByAlias,
   getMemberByAddress,
+  getMemberBySelf,
 }

--- a/app/api-v1/services/identityService.js
+++ b/app/api-v1/services/identityService.js
@@ -24,20 +24,20 @@ const getMemberByAlias = async (req, alias) => {
   throw new InternalError({ message: 'Internal server error' })
 }
 
-const getMemberBySelf = async (req) => {
-  const response = await fetch(`${URL_PREFIX}/self`, {
+const getMemberBySelf = async (req, alias) => {
+  const response = await fetch(`${URL_PREFIX}/self/${encodeURIComponent(alias)}`, {
     headers: {
       Authorization: `Bearer ${req.token}`,
     },
   })
 
+  if (response.status === 404) {
+    throw new BadRequestError({ message: `Self does not exist` })
+  }
+
   if (response.ok) {
     const member = await response.json()
     return member
-  }
-
-  if (response.status === 404) {
-    throw new BadRequestError({ message: `Self does not exist` })
   }
 
   throw new InternalError({ message: 'Internal server error' })

--- a/app/api-v1/services/orderService.js
+++ b/app/api-v1/services/orderService.js
@@ -1,5 +1,5 @@
 const { postOrderDb, getRecipeByIDs } = require('../../db')
-const { BadRequestError, IncorrectSupplierError, RecipeDoesNoExistError } = require('../../utils/errors')
+const { IncorrectSupplierError, RecipeDoesNotExistError } = require('../../utils/errors')
 
 async function postOrder(reqBody) {
   // Will add a get function at a later date to check for duplication
@@ -8,7 +8,7 @@ async function postOrder(reqBody) {
   const uniqueRecipeIDs = [...new Set(reqBody.items)]
   const recipes = await getRecipeByIDs(uniqueRecipeIDs)
   if (recipes.length != uniqueRecipeIDs.length) {
-    throw new RecipeDoesNoExistError({ message: 'Order post error - Recipe does not exist', service: 'order' })
+    throw new RecipeDoesNotExistError({ message: 'Order post error - Recipe does not exist', service: 'order' })
   } else {
     recipes.forEach((recipeItem) => {
       if (recipeItem.supplier != reqBody.supplier) {
@@ -17,12 +17,8 @@ async function postOrder(reqBody) {
     })
   }
 
-  const result = await postOrderDb(reqBody)
-  if (!result) {
-    throw new BadRequestError({ message: 'Order post error', service: 'order' })
-  } else {
-    return { statusCode: 201, result }
-  }
+  const [result] = await postOrderDb({ ...reqBody, status: 'Created' })
+  return { statusCode: 201, result }
 }
 
 module.exports = {

--- a/app/api-v1/services/orderService.js
+++ b/app/api-v1/services/orderService.js
@@ -6,6 +6,7 @@ async function postOrder(reqBody) {
 
   // This section checks if the order manufacturer does not match the supplier
   const uniqueRecipeIDs = [...new Set(reqBody.items)]
+
   const recipes = await getRecipeByIDs(uniqueRecipeIDs)
   if (recipes.length != uniqueRecipeIDs.length) {
     throw new RecipeDoesNotExistError({ message: 'Order post error - Recipe does not exist', service: 'order' })

--- a/app/db.js
+++ b/app/db.js
@@ -22,6 +22,7 @@ async function postOrderDb(reqBody) {
       supplier: reqBody.supplier,
       required_by: reqBody.requiredBy,
       items: reqBody.items,
+      purchaser_address: reqBody.purchaserAddress,
     })
     .returning('*')
 }

--- a/app/db/index.js
+++ b/app/db/index.js
@@ -21,7 +21,8 @@ async function postOrderDb(reqBody) {
       supplier: reqBody.supplier,
       required_by: reqBody.requiredBy,
       items: reqBody.items,
-      purchaser_address: reqBody.purchaserAddress,
+      purchaser: reqBody.purchaserAddress,
+      status: reqBody.status,
     })
     .returning('*')
 }

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -35,13 +35,13 @@ class UnauthorizedError extends HttpResponseError {
 
 class IncorrectSupplierError extends HttpResponseError {
   constructor({ message }) {
-    super({ code: 422, message })
+    super({ code: 400, message })
   }
 }
 
-class RecipeDoesNoExistError extends HttpResponseError {
+class RecipeDoesNotExistError extends HttpResponseError {
   constructor({ message }) {
-    super({ code: 422, message })
+    super({ code: 400, message })
   }
 }
 
@@ -81,6 +81,6 @@ module.exports = {
   NotFoundError,
   IncorrectSupplierError,
   InternalError,
-  RecipeDoesNoExistError,
+  RecipeDoesNotExistError,
   ItemNotFoundError,
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,9 +33,9 @@ services:
       npx knex migrate:latest &&
       node app/index.js"
     ports:
-      - 3002:3001
+      - 3002:3002
     environment:
-      - PORT=3001
+      - PORT=3002
       - API_HOST=dscp-node
       - AUTH_JWKS_URI=https://inteli.eu.auth0.com/.well-known/jwks.json
       - AUTH_AUDIENCE=inteli-dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - inteli-api-storage:/var/lib/postgresql/data
     environment:
+      - PORT=3003
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=inteli

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
     volumes:
       - inteli-api-storage:/var/lib/postgresql/data
     environment:
-      - PORT=3003
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_DB=inteli

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
       - DB_NAME=dscp
       - DB_USERNAME=postgres
       - DB_PASSWORD=postgres
+      - SELF_ADDRESS=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
 
   dscp-node:
     image: ghcr.io/digicatapult/dscp-node:latest

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.14.0'
+appVersion: '1.15.0'
 description: A Helm chart for inteli-api
-version: '1.14.0'
+version: '1.15.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.12.0'
+appVersion: '1.13.0'
 description: A Helm chart for inteli-api
-version: '1.12.0'
+version: '1.13.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.15.0'
+appVersion: '1.16.0'
 description: A Helm chart for inteli-api
-version: '1.15.0'
+version: '1.16.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.17.0'
+appVersion: '1.18.0'
 description: A Helm chart for inteli-api
-version: '1.17.0'
+version: '1.18.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.16.0'
+appVersion: '1.17.0'
 description: A Helm chart for inteli-api
-version: '1.16.0'
+version: '1.17.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -26,7 +26,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.15.0'
+  tag: 'v1.16.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -26,7 +26,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.17.0'
+  tag: 'v1.18.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -26,7 +26,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.16.0'
+  tag: 'v1.17.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -26,7 +26,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.14.0'
+  tag: 'v1.15.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -16,7 +16,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.12.0'
+  tag: 'v1.13.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/migrations/20220516100946_orders.js
+++ b/migrations/20220516100946_orders.js
@@ -10,6 +10,7 @@ exports.up = async (knex) => {
     def.uuid('id').defaultTo(uuidGenerateV4())
     def.string('supplier', 255).notNullable()
     def.specificType('items', 'uuid Array').notNullable()
+    def.string('purchaser_address', '255').notNullable()
     def.datetime('required_by').notNullable()
     def.datetime('created_at').notNullable().default(now())
     def.datetime('updated_at').notNullable().default(now())

--- a/migrations/20220516100946_orders.js
+++ b/migrations/20220516100946_orders.js
@@ -8,9 +8,15 @@ exports.up = async (knex) => {
 
   await knex.schema.createTable('orders', (def) => {
     def.uuid('id').defaultTo(uuidGenerateV4())
-    def.string('supplier', 255).notNullable()
+    def.string('supplier', 48).notNullable()
     def.specificType('items', 'uuid Array').notNullable()
-    def.string('purchaser_address', '255').notNullable()
+    def.string('purchaser', 48).notNullable()
+    def
+      .enu('status', ['Created', 'Submitted', 'Rejected', 'Amended', 'Accepted'], {
+        useNative: true,
+        enumName: 'status',
+      })
+      .notNullable()
     def.datetime('required_by').notNullable()
     def.datetime('created_at').notNullable().default(now())
     def.datetime('updated_at').notNullable().default(now())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/test/helper/identityHelper.js
+++ b/test/helper/identityHelper.js
@@ -6,6 +6,7 @@ const { IDENTITY_SERVICE_HOST, IDENTITY_SERVICE_PORT } = require('../../app/env'
 const setupIdentityMock = function () {
   beforeEach(async function () {
     nock(`http://${IDENTITY_SERVICE_HOST}:${IDENTITY_SERVICE_PORT}`)
+      .persist()
       .get('/v1/members/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
       .reply(200, {
         alias: 'valid-1',
@@ -26,6 +27,8 @@ const setupIdentityMock = function () {
         alias: 'valid-2',
         address: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
       })
+      .get('/v1/self')
+      .reply(200, '"5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY"')
       .get('/v1/members/invalid')
       .reply(404, {})
       .get('/v1/members/error')

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -69,15 +69,26 @@ describe('order', function () {
       expect(response.status).to.equal(400)
     })
 
-    test('POST Order with more than one item - 400', async function () {
+    test('POST Order with more than one item - 201', async function () {
       const newProject = {
-        supplier: 'foobar3000',
+        supplier: 'valid-1',
         requiredBy: new Date().toISOString(),
-        items: ['10000000-0000-2000-9000-000000000000', '10000000-0000-1000-8000-000000000000'],
+        items: ['10000000-0000-1000-8000-000000000000', '10000000-0000-1000-8000-000000000000'],
       }
 
       const response = await postOrderRoute(newProject, app, authToken)
-      expect(response.status).to.equal(400)
+      expect(response.status).to.equal(201)
+    })
+
+    test('POST Order with 2 different items - 201', async function () {
+      const newProject = {
+        supplier: 'valid-1',
+        requiredBy: new Date().toISOString(),
+        items: ['10000000-0000-1000-9000-000000000000', '10000000-0000-1000-8000-000000000000'],
+      }
+
+      const response = await postOrderRoute(newProject, app, authToken)
+      expect(response.status).to.equal(201)
     })
 
     test('POST Order with incorrect supplier - 400', async function () {

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -46,14 +46,15 @@ describe('order', function () {
 
       nock(`http://${IDENTITY_SERVICE_HOST}:${IDENTITY_SERVICE_PORT}`)
         .persist()
-        .get('/v1/members/supplier3000')
+        .get('/v1/self/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
         .reply(200, {
-          alias: 'supplier3000',
-          address: '4FHold46xGXgs5mUiveU2sbTyGBzmstUspZC92UhjJM694jz',
+          alias: 'foobar3000',
         })
-        .get('/v1/members/invalid')
+        .get('/v1/self/')
+        .reply(400, {})
+        .get('/v1/self/invalid')
         .reply(404, {})
-        .get('/v1/members/error')
+        .get('/v1/self/error')
         .reply(500, {})
     })
 
@@ -61,7 +62,7 @@ describe('order', function () {
       nock.cleanAll()
     })
 
-    test.only('POST Order with existing supplier - 201', async function () {
+    test('POST Order with existing supplier - 201', async function () {
       const newRecipe = {
         externalId: 'foobar3000',
         name: 'foobar3000',
@@ -78,63 +79,13 @@ describe('order', function () {
         supplier: 'foobar3000',
         requiredBy: new Date().toISOString(),
         items: [recipeResponse.body.id],
-        purchaserAddress: 'this is an address!!!',
+        purchaserAddress: '',
       }
 
       const response = await postOrderRoute(newOrder, app, authToken)
-      console.log('** response.body', response.body)
-
-      console.log('** response.text', response.text)
 
       expect(response.status).to.equal(201)
       expect(response.body.supplier).deep.equal(newOrder.supplier)
-    })
-
-    test('POST Order with existing supplier - 201', async function () {
-      const newRecipe = {
-        externalId: 'supplier3000',
-        name: 'supplier3000',
-        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
-        material: 'supplier3000',
-        alloy: 'supplier3000',
-        price: 'supplier3000',
-        requiredCerts: [{ description: 'supplier3000' }],
-        supplier: 'supplier3000',
-      }
-
-      const recipeResponse = await postRecipeRoute(newRecipe, app, authToken)
-      const newOrder = {
-        supplier: 'supplier3000',
-        requiredBy: new Date().toISOString(),
-        items: [recipeResponse.body.id],
-      }
-
-      const response = await postOrderRoute(newOrder, app, authToken)
-      expect(response.status).to.equal(201)
-      expect(response.body.supplier).deep.equal(newOrder.supplier)
-    })
-
-    test('POST Order with existing supplier and non existing supplier - 422', async function () {
-      const newRecipe = {
-        externalId: 'supplier3000',
-        name: 'supplier3000',
-        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
-        material: 'supplier3000',
-        alloy: 'supplier3000',
-        price: 'supplier3000',
-        requiredCerts: [{ description: 'supplier3000' }],
-        supplier: 'supplier3000',
-      }
-
-      const recipeResponse = await postRecipeRoute(newRecipe, app, authToken)
-      const newOrder = {
-        supplier: 'supplier3000',
-        requiredBy: new Date().toISOString(),
-        items: [recipeResponse.body.id, '10000000-0000-2000-9000-000000000000'],
-      }
-
-      const response = await postOrderRoute(newOrder, app, authToken)
-      expect(response.status).to.equal(422)
     })
 
     test('POST Order with non-existant supplier - 422', async function () {
@@ -142,6 +93,7 @@ describe('order', function () {
         supplier: 'foobar3000',
         requiredBy: new Date().toISOString(),
         items: ['00000000-0000-1000-8000-000000000000'],
+        purchaserAddress: '',
       }
 
       const response = await postOrderRoute(newProject, app, authToken)
@@ -153,6 +105,7 @@ describe('order', function () {
         supplier: 'foobar3000',
         requiredBy: new Date().toISOString(),
         items: ['00000000-0000-1000-8000'],
+        purchaserAddress: '',
       }
 
       const response = await postOrderRoute(newProject, app, authToken)
@@ -176,7 +129,7 @@ describe('order', function () {
       expect(response.status).to.equal(400)
     })
 
-    test.skip('POST Order - Check ID & Manufacturer', async function () {
+    test('POST Order - Check ID & Manufacturer', async function () {
       const newRecipe = {
         externalId: 'foobar3000',
         name: 'foobar3000',
@@ -193,37 +146,13 @@ describe('order', function () {
         supplier: 'foobar3000',
         requiredBy: new Date().toISOString(),
         items: [recipeResponse.body.id],
+        purchaserAddress: '',
       }
 
       const response = await postOrderRoute(newOrder, app, authToken)
-      console.log('*** response', response.body)
       expect(response.body.supplier).to.equal(recipeResponse.body.supplier)
       expect(response.body.items).to.contain(recipeResponse.body.id)
       expect(response.status).to.equal(201)
-    })
-
-    test('POST Order - Check ID & Manufacturer - FAIL', async function () {
-      const newRecipe = {
-        externalId: 'foobar3000',
-        name: 'foobar3000',
-        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
-        material: 'foobar3000',
-        alloy: 'foobar3000',
-        price: 'foobar3000',
-        requiredCerts: [{ description: 'foobar3000' }],
-        supplier: 'foobar3000',
-      }
-
-      const recipeResponse = await postRecipeRoute(newRecipe, app, authToken)
-
-      const newOrder = {
-        supplier: 'supplier3000',
-        requiredBy: new Date().toISOString(),
-        items: [recipeResponse.body.id],
-      }
-
-      const response = await postOrderRoute(newOrder, app, authToken)
-      expect(response.status).to.equal(422)
     })
   })
 })

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -61,7 +61,7 @@ describe('order', function () {
       nock.cleanAll()
     })
 
-    test('POST Order with existing supplier - 201', async function () {
+    test.only('POST Order with existing supplier - 201', async function () {
       const newRecipe = {
         externalId: 'foobar3000',
         name: 'foobar3000',
@@ -78,8 +78,14 @@ describe('order', function () {
         supplier: 'foobar3000',
         requiredBy: new Date().toISOString(),
         items: [recipeResponse.body.id],
+        purchaserAddress: 'this is an address!!!',
       }
+
       const response = await postOrderRoute(newOrder, app, authToken)
+      console.log('** response.body', response.body)
+
+      console.log('** response.text', response.text)
+
       expect(response.status).to.equal(201)
       expect(response.body.supplier).deep.equal(newOrder.supplier)
     })
@@ -170,7 +176,7 @@ describe('order', function () {
       expect(response.status).to.equal(400)
     })
 
-    test('POST Order - Check ID & Manufacturer', async function () {
+    test.skip('POST Order - Check ID & Manufacturer', async function () {
       const newRecipe = {
         externalId: 'foobar3000',
         name: 'foobar3000',
@@ -190,6 +196,7 @@ describe('order', function () {
       }
 
       const response = await postOrderRoute(newOrder, app, authToken)
+      console.log('*** response', response.body)
       expect(response.body.supplier).to.equal(recipeResponse.body.supplier)
       expect(response.body.items).to.contain(recipeResponse.body.id)
       expect(response.status).to.equal(201)

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -69,6 +69,17 @@ describe('order', function () {
       expect(response.status).to.equal(400)
     })
 
+    test('POST Order with more than one item - 400', async function () {
+      const newProject = {
+        supplier: 'foobar3000',
+        requiredBy: new Date().toISOString(),
+        items: ['10000000-0000-2000-9000-000000000000', '10000000-0000-1000-8000-000000000000'],
+      }
+
+      const response = await postOrderRoute(newProject, app, authToken)
+      expect(response.status).to.equal(400)
+    })
+
     test('POST Order with incorrect supplier - 400', async function () {
       const newProject = {
         supplier: 'valid-2',

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -1,12 +1,12 @@
 const { describe, before, test } = require('mocha')
 const { expect } = require('chai')
 const createJWKSMock = require('mock-jwks').default
-const nock = require('nock')
 
 const { createHttpServer } = require('../../app/server')
-const { postOrderRoute, postRecipeRoute } = require('../helper/routeHelper')
+const { postOrderRoute } = require('../helper/routeHelper')
+const { setupIdentityMock } = require('../helper/identityHelper')
 const { seed, cleanup } = require('../seeds/orders')
-const { AUTH_ISSUER, AUTH_AUDIENCE, IDENTITY_SERVICE_HOST, IDENTITY_SERVICE_PORT } = require('../../app/env')
+const { AUTH_ISSUER, AUTH_AUDIENCE } = require('../../app/env')
 
 describe('order', function () {
   describe('valid order', function () {
@@ -31,81 +31,60 @@ describe('order', function () {
       await jwksMock.stop()
     })
 
-    beforeEach(async function () {
-      nock(`http://${IDENTITY_SERVICE_HOST}:${IDENTITY_SERVICE_PORT}`)
-        .persist()
-        .get('/v1/members/foobar3000')
-        .reply(200, {
-          alias: 'foobar3000',
-          address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
-        })
-        .get('/v1/members/invalid')
-        .reply(404, {})
-        .get('/v1/members/error')
-        .reply(500, {})
-
-      nock(`http://${IDENTITY_SERVICE_HOST}:${IDENTITY_SERVICE_PORT}`)
-        .persist()
-        .get('/v1/self/5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty')
-        .reply(200, {
-          alias: 'foobar3000',
-        })
-        .get('/v1/self/')
-        .reply(400, {})
-        .get('/v1/self/invalid')
-        .reply(404, {})
-        .get('/v1/self/error')
-        .reply(500, {})
-    })
-
-    afterEach(async function () {
-      nock.cleanAll()
-    })
+    setupIdentityMock()
 
     test('POST Order with existing supplier - 201', async function () {
-      const newRecipe = {
-        externalId: 'foobar3000',
-        name: 'foobar3000',
-        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
-        material: 'foobar3000',
-        alloy: 'foobar3000',
-        price: 'foobar3000',
-        requiredCerts: [{ description: 'foobar3000' }],
-        supplier: 'foobar3000',
-      }
-
-      const recipeResponse = await postRecipeRoute(newRecipe, app, authToken)
       const newOrder = {
-        supplier: 'foobar3000',
+        supplier: 'valid-1',
         requiredBy: new Date().toISOString(),
-        items: [recipeResponse.body.id],
-        purchaserAddress: '',
+        items: ['10000000-0000-1000-8000-000000000000'],
       }
-
       const response = await postOrderRoute(newOrder, app, authToken)
 
       expect(response.status).to.equal(201)
       expect(response.body.supplier).deep.equal(newOrder.supplier)
     })
 
-    test('POST Order with non-existant supplier - 422', async function () {
+    test('POST Order - Check ID & Manufacturer', async function () {
+      const newOrder = {
+        supplier: 'valid-1',
+        requiredBy: new Date().toISOString(),
+        items: ['10000000-0000-1000-8000-000000000000'],
+      }
+      const response = await postOrderRoute(newOrder, app, authToken)
+      expect(response.body.supplier).to.equal('valid-1')
+      expect(response.body.purchaser).to.equal('valid-2')
+      expect(response.body.items).to.contain('10000000-0000-1000-8000-000000000000')
+      expect(response.status).to.equal(201)
+    })
+
+    test('POST Order with non-existant supplier - 400', async function () {
       const newProject = {
         supplier: 'foobar3000',
         requiredBy: new Date().toISOString(),
-        items: ['00000000-0000-1000-8000-000000000000'],
-        purchaserAddress: '',
+        items: ['10000000-0000-1000-8000-000000000000'],
       }
 
       const response = await postOrderRoute(newProject, app, authToken)
-      expect(response.status).to.equal(422)
+      expect(response.status).to.equal(400)
+    })
+
+    test('POST Order with incorrect supplier - 400', async function () {
+      const newProject = {
+        supplier: 'valid-2',
+        requiredBy: new Date().toISOString(),
+        items: ['10000000-0000-1000-8000-000000000000'],
+      }
+
+      const response = await postOrderRoute(newProject, app, authToken)
+      expect(response.status).to.equal(400)
     })
 
     test('POST Order - Invalid UUID', async function () {
       const newProject = {
-        supplier: 'foobar3000',
+        supplier: 'valid-1',
         requiredBy: new Date().toISOString(),
         items: ['00000000-0000-1000-8000'],
-        purchaserAddress: '',
       }
 
       const response = await postOrderRoute(newProject, app, authToken)
@@ -127,32 +106,6 @@ describe('order', function () {
 
       const response = await postOrderRoute(newProject, app, authToken)
       expect(response.status).to.equal(400)
-    })
-
-    test('POST Order - Check ID & Manufacturer', async function () {
-      const newRecipe = {
-        externalId: 'foobar3000',
-        name: 'foobar3000',
-        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
-        material: 'foobar3000',
-        alloy: 'foobar3000',
-        price: 'foobar3000',
-        requiredCerts: [{ description: 'foobar3000' }],
-        supplier: 'foobar3000',
-      }
-
-      const recipeResponse = await postRecipeRoute(newRecipe, app, authToken)
-      const newOrder = {
-        supplier: 'foobar3000',
-        requiredBy: new Date().toISOString(),
-        items: [recipeResponse.body.id],
-        purchaserAddress: '',
-      }
-
-      const response = await postOrderRoute(newOrder, app, authToken)
-      expect(response.body.supplier).to.equal(recipeResponse.body.supplier)
-      expect(response.body.items).to.contain(recipeResponse.body.id)
-      expect(response.status).to.equal(201)
     })
   })
 })

--- a/test/seeds/orders.js
+++ b/test/seeds/orders.js
@@ -34,7 +34,7 @@ const seed = async () => {
 
   await client('recipes').insert([
     {
-      id: '10000000-0000-2000-9000-000000000000',
+      id: '10000000-0000-1000-9000-000000000000',
       external_id: 'supplier3000',
       name: 'supplier3000',
       image_attachment_id: '00000000-0000-1000-8000-000000000000',
@@ -42,7 +42,7 @@ const seed = async () => {
       alloy: 'supplier3000',
       price: 'supplier3000',
       required_certs: JSON.stringify([{ description: 'supplier3000' }]),
-      supplier: '4FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+      supplier: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
     },
   ])
 }

--- a/test/seeds/orders.js
+++ b/test/seeds/orders.js
@@ -31,6 +31,20 @@ const seed = async () => {
       supplier: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
     },
   ])
+
+  await client('recipes').insert([
+    {
+      id: '10000000-0000-2000-9000-000000000000',
+      external_id: 'supplier3000',
+      name: 'supplier3000',
+      image_attachment_id: '00000000-0000-1000-8000-000000000000',
+      material: 'supplier3000',
+      alloy: 'supplier3000',
+      price: 'supplier3000',
+      required_certs: JSON.stringify([{ description: 'supplier3000' }]),
+      supplier: '4FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+    },
+  ])
 }
 
 module.exports = {

--- a/test/seeds/orders.js
+++ b/test/seeds/orders.js
@@ -17,6 +17,20 @@ const seed = async () => {
       binary_blob: 9999999,
     },
   ])
+
+  await client('recipes').insert([
+    {
+      id: '10000000-0000-1000-8000-000000000000',
+      external_id: 'foobar3000',
+      name: 'foobar3000',
+      image_attachment_id: '00000000-0000-1000-8000-000000000000',
+      material: 'foobar3000',
+      alloy: 'foobar3000',
+      price: 'foobar3000',
+      required_certs: JSON.stringify([{ description: 'foobar3000' }]),
+      supplier: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+    },
+  ])
 }
 
 module.exports = {


### PR DESCRIPTION
This adds the `self` endpoint from the identity service to align with [here](https://github.com/digicatapult/dscp-identity-service/pull/16/files#diff-fd92b97774d4da647aa7570808769e794c9ac6996d8486427de4fe7038d72770)

A `purchaser` column has also been added to the database as per [this ticket](https://digicatapult.atlassian.net/jira/software/projects/IN/boards/115?selectedIssue=IN-232)

