### PR TITLE
Add AUTH_TYPE env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Dependency Check
         run: npm run depcheck
   tests:
+    strategy:
+      matrix:
+        auth: [NONE, JWT]
     name: Run tests
     runs-on: ubuntu-latest
     needs: [preconditions]
@@ -163,6 +166,9 @@ jobs:
         run: npm ci
       - name: Setup dependencies
         run: docker-compose up -d
+        env: 
+          IDENTITY_AUTH_TYPE: ${{ matrix.auth }}
+          DSCP_API_AUTH_TYPE: ${{ matrix.auth }}
       - name: Sleep
         uses: kibertoad/wait-action@1.0.1
         with:
@@ -172,6 +178,7 @@ jobs:
       - name: Run tests
         run: npm run test
         env:
+          AUTH_TYPE: ${{ matrix.auth }}
           AUTH_TEST_USERNAME: ${{ secrets.AUTH_TEST_USERNAME }}
           AUTH_TEST_PASSWORD: ${{ secrets.AUTH_TEST_PASSWORD }}
           AUTH_TEST_CLIENT_ID: ${{ secrets.AUTH_TEST_CLIENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,7 @@ jobs:
       - name: Setup dependencies
         run: docker-compose up -d
         env: 
-          IDENTITY_AUTH_TYPE: ${{ matrix.auth }}
-          DSCP_API_AUTH_TYPE: ${{ matrix.auth }}
+          AUTH_TYPE: ${{ matrix.auth }}
       - name: Sleep
         uses: kibertoad/wait-action@1.0.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,8 +159,7 @@ jobs:
       - name: Setup dependencies
         run: docker-compose up -d
         env: 
-          IDENTITY_AUTH_TYPE: ${{ matrix.auth }}
-          DSCP_API_AUTH_TYPE: ${{ matrix.auth }}
+          AUTH_TYPE: ${{ matrix.auth }}
       - name: Sleep
         uses: kibertoad/wait-action@1.0.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,6 +136,9 @@ jobs:
         run: npm run depcheck
 
   tests:
+    strategy:
+      matrix:
+        auth: [NONE, JWT]
     name: Run tests
     runs-on: ubuntu-latest
     steps:
@@ -155,6 +158,9 @@ jobs:
         run: npm ci
       - name: Setup dependencies
         run: docker-compose up -d
+        env: 
+          IDENTITY_AUTH_TYPE: ${{ matrix.auth }}
+          DSCP_API_AUTH_TYPE: ${{ matrix.auth }}
       - name: Sleep
         uses: kibertoad/wait-action@1.0.1
         with:
@@ -166,6 +172,7 @@ jobs:
       - name: Run integration tests
         run: npm run test
         env:
+          AUTH_TYPE: ${{ matrix.auth }}
           AUTH_TEST_USERNAME: ${{ secrets.AUTH_TEST_USERNAME }}
           AUTH_TEST_PASSWORD: ${{ secrets.AUTH_TEST_PASSWORD }}
           AUTH_TEST_CLIENT_ID: ${{ secrets.AUTH_TEST_CLIENT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 .DS_Store
 .nyc_output
+coverage.json
 .idea
 .env
 .vscode

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Once a test application and user is created, running integration tests locally r
 Start dependencies with `AUTH_TYPE: 'JWT'`:
 
 ```
-IDENTITY_AUTH_TYPE=JWT DSCP_API_AUTH_TYPE=JWT docker compose up -d
+AUTH_TYPE=JWT docker compose up -d
 ```
 
 Run tests:

--- a/README.md
+++ b/README.md
@@ -6,27 +6,33 @@ Inteli OpenAPI service for interacting with the DSCP (Digital Supply-Chain Platf
 
 `inteli-api` is configured primarily using environment variables as follows:
 
-| variable                     | required |                       default                       | description                                                                          |
-| :--------------------------- | :------: | :-------------------------------------------------: | :----------------------------------------------------------------------------------- |
-| SERVICE_TYPE                 |    N     |                       `info`                        | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
-| PORT                         |    N     |                        `80`                         | The port for the API to listen on                                                    |
-| LOG_LEVEL                    |    N     |                       `info`                        | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
-| API_VERSION                  |    N     |               `package.json version`                | API version                                                                          |
-| API_MAJOR_VERSION            |    N     |                        `v1`                         | API major version                                                                    |
-| DSCP_API_HOST                |    Y     |                          -                          | `dscp-api` host                                                                      |
-| DSCP_API_PORT                |    Y     |                          -                          | `dscp-api` port                                                                      |
-| DB_HOST                      |    Y     |                          -                          | PostgreSQL database hostname                                                         |
-| DB_PORT                      |    N     |                       `5432`                        | PostgreSQL database port                                                             |
-| DB_NAME                      |    N     |                      `inteli`                       | PostgreSQL database name                                                             |
-| DB_USERNAME                  |    Y     |                          -                          | PostgreSQL database username                                                         |
-| DB_PASSWORD                  |    Y     |                          -                          | PostgreSQL database password                                                         |
-| FILE_UPLOAD_SIZE_LIMIT_BYTES |    N     |                 `1024 * 1024 * 100`                 | Maximum file size in bytes for upload                                                |
-| AUTH_JWKS_URI                |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API                        |
-| AUTH_AUDIENCE                |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                                          |
-| AUTH_ISSUER                  |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                                            |
-| AUTH_TOKEN_URL               |    N     |      `https://inteli.eu.auth0.com/oauth/token`      | Auth0 API endpoint that issues an Authorisation (Bearer) access token                |
-| IDENTITY_SERVICE_HOST        |    Y     |                                                     | Hostname of the `dscp-identity-service`                                              |
-| IDENTITY_SERVICE_PORT        |    Y     |                                                     | Port of the `dscp-identity-service`                                                  |
+| variable                     | required |        default         | description                                                                          |
+| :--------------------------- | :------: | :--------------------: | :----------------------------------------------------------------------------------- |
+| SERVICE_TYPE                 |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
+| PORT                         |    N     |          `80`          | The port for the API to listen on                                                    |
+| LOG_LEVEL                    |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
+| API_VERSION                  |    N     | `package.json version` | API version                                                                          |
+| API_MAJOR_VERSION            |    N     |          `v1`          | API major version                                                                    |
+| DSCP_API_HOST                |    Y     |           -            | `dscp-api` host                                                                      |
+| DSCP_API_PORT                |    Y     |           -            | `dscp-api` port                                                                      |
+| DB_HOST                      |    Y     |           -            | PostgreSQL database hostname                                                         |
+| DB_PORT                      |    N     |         `5432`         | PostgreSQL database port                                                             |
+| DB_NAME                      |    N     |        `inteli`        | PostgreSQL database name                                                             |
+| DB_USERNAME                  |    Y     |           -            | PostgreSQL database username                                                         |
+| DB_PASSWORD                  |    Y     |           -            | PostgreSQL database password                                                         |
+| FILE_UPLOAD_SIZE_LIMIT_BYTES |    N     |  `1024 * 1024 * 100`   | Maximum file size in bytes for upload                                                |
+| IDENTITY_SERVICE_HOST        |    Y     |                        | Hostname of the `dscp-identity-service`                                              |
+| IDENTITY_SERVICE_PORT        |    Y     |                        | Port of the `dscp-identity-service`                                                  |
+| AUTH_TYPE                    |    N     |         `NONE`         | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]         |
+
+The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
+
+| variable       | required |                       default                       | description                                                           |
+| :------------- | :------: | :-------------------------------------------------: | :-------------------------------------------------------------------- |
+| AUTH_JWKS_URI  |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API         |
+| AUTH_AUDIENCE  |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                           |
+| AUTH_ISSUER    |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                             |
+| AUTH_TOKEN_URL |    N     |      `https://inteli.eu.auth0.com/oauth/token`      | Auth0 API endpoint that issues an Authorisation (Bearer) access token |
 
 ## Getting started
 
@@ -50,11 +56,11 @@ npm run dev
 
 ## Authentication
 
-The endpoints on `inteli-api` require Bearer Authentication using a JSON Web Token. Tokens are generated externally as an Auth0 Machine to Machine token. You will need to create your own Auth0 API, which can be done for free, and set the appropriate [environment variables](#configuration) (those prefixed with `AUTH`). Follow the start of this [tutorial](https://auth0.com/docs/quickstart/backend/nodejs#configure-auth0-apis) to create an API. Go [here](app/routes/auth.js) and [here](app/auth.js) to see where the environment variables are used.
+If `AUTH_TYPE` env is set to `JWT`, the endpoints on `inteli-api` require Bearer Authentication using a JSON Web Token. Tokens are generated externally as an Auth0 Machine to Machine token. You will need to create your own Auth0 API, which can be done for free, and set the appropriate [environment variables](#configuration) (those prefixed with `AUTH`). Follow the start of this [tutorial](https://auth0.com/docs/quickstart/backend/nodejs#configure-auth0-apis) to create an API. Go [here](app/routes/auth.js) and [here](app/auth.js) to see where the environment variables are used.
 
 ## Testing
 
-Integration tests use a preconfigured Auth0 test application and user to authenticate across multiple `dscp` services. Follow the tutorial [here](https://auth0.com/docs/get-started/authentication-and-authorization-flow/call-your-api-using-resource-owner-password-flow) to create your own.
+Integration tests for `AUTH_TYPE: 'JWT'` use a preconfigured Auth0 test application and user to authenticate across multiple `dscp` services. Follow the tutorial [here](https://auth0.com/docs/get-started/authentication-and-authorization-flow/call-your-api-using-resource-owner-password-flow) to create your own.
 
 Once a test application and user is created, running integration tests locally requires a `/test/test.env` file containing the following environment variables:
 
@@ -64,3 +70,15 @@ Once a test application and user is created, running integration tests locally r
 | AUTH_TEST_PASSWORD      |    Y     |    -    | Password of the auth0 user for testing             |
 | AUTH_TEST_CLIENT_ID     |    Y     |    -    | Client ID of the auth0 application for testing     |
 | AUTH_TEST_CLIENT_SECRET |    Y     |    -    | Client secret of the auth0 application for testing |
+
+Start dependencies with `AUTH_TYPE: 'JWT'`:
+
+```
+IDENTITY_AUTH_TYPE=JWT DSCP_API_AUTH_TYPE=JWT docker compose up -d
+```
+
+Run tests:
+
+```
+npm run test:jwt
+```

--- a/app/api-v1/routes/attachment.js
+++ b/app/api-v1/routes/attachment.js
@@ -1,5 +1,6 @@
 const logger = require('../../utils/Logger')
 const { BadRequestError } = require('../../utils/errors')
+const { getDefaultSecurity } = require('../../utils/auth')
 
 module.exports = function (attachmentService) {
   const doc = {
@@ -54,7 +55,7 @@ module.exports = function (attachmentService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['attachment'],
   }
 
@@ -123,7 +124,7 @@ module.exports = function (attachmentService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['attachment'],
   }
 

--- a/app/api-v1/routes/attachment/{id}.js
+++ b/app/api-v1/routes/attachment/{id}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (attachmentService) {
   const doc = {
@@ -61,7 +63,7 @@ module.exports = function (attachmentService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['attachment'],
   }
 

--- a/app/api-v1/routes/build.js
+++ b/app/api-v1/routes/build.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService, partService) {
   const doc = {
@@ -37,7 +39,7 @@ module.exports = function (buildService, partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 
@@ -84,7 +86,7 @@ module.exports = function (buildService, partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}.js
+++ b/app/api-v1/routes/build/{id}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -55,7 +57,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/completion.js
+++ b/app/api-v1/routes/build/{id}/completion.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/completion/{completionId}.js
+++ b/app/api-v1/routes/build/{id}/completion/{completionId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/progress-update.js
+++ b/app/api-v1/routes/build/{id}/progress-update.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/progress-update/{updateId}.js
+++ b/app/api-v1/routes/build/{id}/progress-update/{updateId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/schedule.js
+++ b/app/api-v1/routes/build/{id}/schedule.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/schedule/{scheduleId}.js
+++ b/app/api-v1/routes/build/{id}/schedule/{scheduleId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/start.js
+++ b/app/api-v1/routes/build/{id}/start.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/build/{id}/start/{startId}.js
+++ b/app/api-v1/routes/build/{id}/start/{startId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (buildService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (buildService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['build'],
   }
 

--- a/app/api-v1/routes/order.js
+++ b/app/api-v1/routes/order.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 const { BadRequestError } = require('../../utils/errors')
+const { getDefaultSecurity } = require('../../utils/auth')
+
 module.exports = function (orderService, identityService) {
   const doc = {
     GET: async function (req, res) {
@@ -57,7 +59,7 @@ module.exports = function (orderService, identityService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 
@@ -104,7 +106,7 @@ module.exports = function (orderService, identityService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}.js
+++ b/app/api-v1/routes/order/{id}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -55,7 +57,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/acceptance.js
+++ b/app/api-v1/routes/order/{id}/acceptance.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/acceptance/{acceptanceId}.js
+++ b/app/api-v1/routes/order/{id}/acceptance/{acceptanceId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/amendment.js
+++ b/app/api-v1/routes/order/{id}/amendment.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/amendment/{amendmentId}.js
+++ b/app/api-v1/routes/order/{id}/amendment/{amendmentId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/rejection.js
+++ b/app/api-v1/routes/order/{id}/rejection.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -116,7 +118,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/rejection/{rejectionId}.js
+++ b/app/api-v1/routes/order/{id}/rejection/{rejectionId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/submission.js
+++ b/app/api-v1/routes/order/{id}/submission.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -116,7 +118,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/order/{id}/submission/{submissionId}.js
+++ b/app/api-v1/routes/order/{id}/submission/{submissionId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (orderService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (orderService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['order'],
   }
 

--- a/app/api-v1/routes/part.js
+++ b/app/api-v1/routes/part.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -34,7 +36,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}.js
+++ b/app/api-v1/routes/part/{id}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -55,7 +57,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}/certification.js
+++ b/app/api-v1/routes/part/{id}/certification.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -116,7 +118,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}/certification/{certificationId}.js
+++ b/app/api-v1/routes/part/{id}/certification/{certificationId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}/metadata-update.js
+++ b/app/api-v1/routes/part/{id}/metadata-update.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}/metadata-update/{updateId}.js
+++ b/app/api-v1/routes/part/{id}/metadata-update/{updateId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}/order-assignment.js
+++ b/app/api-v1/routes/part/{id}/order-assignment.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -58,7 +60,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 
@@ -117,7 +119,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/part/{id}/order-assignment/{assignmentId}.js
+++ b/app/api-v1/routes/part/{id}/order-assignment/{assignmentId}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (partService) {
   const doc = {
@@ -62,7 +64,7 @@ module.exports = function (partService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['part'],
   }
 

--- a/app/api-v1/routes/recipe.js
+++ b/app/api-v1/routes/recipe.js
@@ -1,6 +1,7 @@
 const logger = require('../../utils/Logger')
 const { buildValidatedJsonHandler } = require('../../utils/routeResponseValidator')
 const { BadRequestError } = require('../../utils/errors')
+const { getDefaultSecurity } = require('../../utils/auth')
 
 // eslint-disable-next-line no-unused-vars
 module.exports = function (recipeService, identityService) {
@@ -57,7 +58,7 @@ module.exports = function (recipeService, identityService) {
             },
           },
         },
-        security: [{ bearerAuth: [] }],
+        security: getDefaultSecurity(),
         tags: ['recipe'],
       }
     ),
@@ -139,7 +140,7 @@ module.exports = function (recipeService, identityService) {
             },
           },
         },
-        security: [{ bearerAuth: [] }],
+        security: getDefaultSecurity(),
         tags: ['recipe'],
       }
     ),

--- a/app/api-v1/routes/recipe/{id}.js
+++ b/app/api-v1/routes/recipe/{id}.js
@@ -1,3 +1,5 @@
+const { getDefaultSecurity } = require('../../../utils/auth')
+
 // eslint-disable-next-line no-unused-vars
 module.exports = function (recipeService) {
   const doc = {
@@ -55,7 +57,7 @@ module.exports = function (recipeService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['recipe'],
   }
 

--- a/app/api-v1/routes/recipe/{id}/creation.js
+++ b/app/api-v1/routes/recipe/{id}/creation.js
@@ -1,5 +1,6 @@
 const { transaction } = require('../../../controllers/Recipe')
 const { buildValidatedJsonHandler } = require('../../../../utils/routeResponseValidator')
+const { getDefaultSecurity } = require('../../../../utils/auth')
 
 module.exports = function () {
   const doc = {
@@ -115,7 +116,7 @@ module.exports = function () {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['recipe'],
   }
 

--- a/app/api-v1/routes/recipe/{id}/creation/{creationId}.js
+++ b/app/api-v1/routes/recipe/{id}/creation/{creationId}.js
@@ -1,4 +1,5 @@
 const { transaction } = require('../../../../controllers/Recipe')
+const { getDefaultSecurity } = require('../../../../../utils/auth')
 
 // eslint-disable-next-line no-unused-vars
 module.exports = function (recipeService) {
@@ -68,7 +69,7 @@ module.exports = function (recipeService) {
         },
       },
     },
-    security: [{ bearerAuth: [] }],
+    security: getDefaultSecurity(),
     tags: ['recipe'],
   }
 

--- a/app/env.js
+++ b/app/env.js
@@ -8,9 +8,24 @@ if (process.env.NODE_ENV === 'test') {
   dotenv.config({ path: '.env' })
 }
 
+const AUTH_ENVS = {
+  NONE: {},
+  JWT: {
+    AUTH_JWKS_URI: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/.well-known/jwks.json' }),
+    AUTH_AUDIENCE: envalid.str({ devDefault: 'inteli-dev' }),
+    AUTH_ISSUER: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/' }),
+    AUTH_TOKEN_URL: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/oauth/token' }),
+  },
+}
+
+const { AUTH_TYPE } = envalid.cleanEnv(process.env, {
+  AUTH_TYPE: envalid.str({ default: 'NONE', choices: ['NONE', 'JWT'] }),
+})
+
 const vars = envalid.cleanEnv(
   process.env,
   {
+    ...AUTH_ENVS[AUTH_TYPE],
     SERVICE_TYPE: envalid.str({ default: 'inteli-api'.toUpperCase().replace(/-/g, '_') }),
     PORT: envalid.port({ default: 80, devDefault: 3000 }),
     API_VERSION: envalid.str({ default: version }),
@@ -24,10 +39,6 @@ const vars = envalid.cleanEnv(
     DB_USERNAME: envalid.str({ devDefault: 'postgres' }),
     DB_PASSWORD: envalid.str({ devDefault: 'postgres' }),
     FILE_UPLOAD_SIZE_LIMIT_BYTES: envalid.num({ default: 1024 * 1024 * 100, devDefault: 1024 * 1024 * 10 }),
-    AUTH_JWKS_URI: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/.well-known/jwks.json' }),
-    AUTH_AUDIENCE: envalid.str({ devDefault: 'inteli-dev' }),
-    AUTH_ISSUER: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/' }),
-    AUTH_TOKEN_URL: envalid.url({ devDefault: 'https://inteli.eu.auth0.com/oauth/token' }),
     IDENTITY_SERVICE_HOST: envalid.host({ devDefault: 'localhost' }),
     IDENTITY_SERVICE_PORT: envalid.port({ devDefault: 3002 }),
   },
@@ -36,4 +47,7 @@ const vars = envalid.cleanEnv(
   }
 )
 
-module.exports = vars
+module.exports = {
+  ...vars,
+  AUTH_TYPE,
+}

--- a/app/server.js
+++ b/app/server.js
@@ -8,7 +8,7 @@ const multer = require('multer')
 const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
-const { PORT, API_VERSION, API_MAJOR_VERSION, FILE_UPLOAD_SIZE_LIMIT_BYTES } = require('./env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, FILE_UPLOAD_SIZE_LIMIT_BYTES, AUTH_TYPE } = require('./env')
 const logger = require('./utils/Logger')
 const v1ApiDoc = require('./api-v1/api-doc')
 const v1RecipeService = require('./api-v1/services/recipeService')
@@ -44,6 +44,13 @@ async function createHttpServer() {
     storage: multer.diskStorage({}),
   }
 
+  const securityHandlers =
+    AUTH_TYPE === 'JWT'
+      ? {
+          bearerAuth: (req) => verifyJwks(req),
+        }
+      : {}
+
   initialize({
     app,
     apiDoc: v1ApiDoc,
@@ -55,9 +62,7 @@ async function createHttpServer() {
         })
       },
     },
-    securityHandlers: {
-      bearerAuth: (req) => verifyJwks(req),
-    },
+    securityHandlers: securityHandlers,
     dependencies: {
       recipeService: v1RecipeService,
       attachmentService: v1AttachmentService,

--- a/app/utils/auth.js
+++ b/app/utils/auth.js
@@ -1,6 +1,6 @@
 const jwksRsa = require('jwks-rsa')
 const jwt = require('jsonwebtoken')
-const { AUTH_JWKS_URI, AUTH_AUDIENCE, AUTH_ISSUER } = require('../env')
+const { AUTH_JWKS_URI, AUTH_AUDIENCE, AUTH_ISSUER, AUTH_TYPE } = require('../env')
 const { UnauthorizedError } = require('../utils/errors')
 
 const client = jwksRsa({
@@ -43,6 +43,18 @@ const verifyJwks = async (req) => {
   })
 }
 
+const getDefaultSecurity = () => {
+  switch (AUTH_TYPE) {
+    case 'NONE':
+      return []
+    case 'JWT':
+      return [{ bearerAuth: [] }]
+    default:
+      return []
+  }
+}
+
 module.exports = {
   verifyJwks,
+  getDefaultSecurity,
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=postgres
       - SELF_ADDRESS=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-      - AUTH_TYPE=${IDENTITY_AUTH_TYPE:-NONE}
+      - AUTH_TYPE=${AUTH_TYPE:-NONE}
 
   dscp-node:
     image: ghcr.io/digicatapult/dscp-node:latest
@@ -94,7 +94,7 @@ services:
       - AUTH_AUDIENCE=inteli-dev
       - AUTH_ISSUER=https://inteli.eu.auth0.com/
       - AUTH_TOKEN_URL=https://inteli.eu.auth0.com/oauth/token
-      - AUTH_TYPE=${DSCP_API_AUTH_TYPE:-NONE}
+      - AUTH_TYPE=${AUTH_TYPE:-NONE}
     restart: on-failure
 volumes:
   inteli-api-storage:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/digicatapult/dscp-identity-service:latest
     container_name: identity-service
     command: /bin/sh -c "
-      sleep 60 &&
+      sleep 30 &&
       npx knex migrate:latest &&
       node app/index.js"
     ports:
@@ -47,6 +47,7 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=postgres
       - SELF_ADDRESS=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
+      - AUTH_TYPE=${IDENTITY_AUTH_TYPE:-NONE}
 
   dscp-node:
     image: ghcr.io/digicatapult/dscp-node:latest
@@ -77,7 +78,7 @@ services:
       - 5001:5001
 
   dscp-api:
-    image: ghcr.io/digicatapult/dscp-api:v4.0.0
+    image: ghcr.io/digicatapult/dscp-api:latest
     container_name: dscp-api
     ports:
       - 3001:3001
@@ -93,6 +94,7 @@ services:
       - AUTH_AUDIENCE=inteli-dev
       - AUTH_ISSUER=https://inteli.eu.auth0.com/
       - AUTH_TOKEN_URL=https://inteli.eu.auth0.com/oauth/token
+      - AUTH_TYPE=${DSCP_API_AUTH_TYPE:-NONE}
     restart: on-failure
 volumes:
   inteli-api-storage:

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.20.3'
+appVersion: '1.22.0'
 description: A Helm chart for inteli-api
-version: '1.20.3'
+version: '1.22.0'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/templates/configmap.yaml
+++ b/helm/inteli-api/templates/configmap.yaml
@@ -12,9 +12,12 @@ data:
   dbHost: {{ include "inteli-api.postgresql.fullname" . }}
   dbPort: {{ .Values.config.dbPort | quote }}
   dbName: {{ .Values.config.dbName }}
+  {{- if eq .Values.config.auth.type "JWT" }}
   authJwksUri: {{ .Values.config.auth.jwksUri }}
   authAudience: {{ .Values.config.auth.audience }}
   authIssuer: {{ .Values.config.auth.issuer }}
   authTokenUrl: {{ .Values.config.auth.tokenUrl }}
+  {{- end }}
   identityServiceHost: {{ .Values.config.identityServiceHost }}
   identityServicePort: {{ .Values.config.identityServicePort | quote }}
+  authType: {{ .Values.config.auth.type }}

--- a/helm/inteli-api/templates/deployment.yaml
+++ b/helm/inteli-api/templates/deployment.yaml
@@ -105,6 +105,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-secret
                   key: dbPassword
+            {{- if eq .Values.config.auth.type "JWT" }}
             - name: AUTH_JWKS_URI
               valueFrom:
                 configMapKeyRef:
@@ -125,6 +126,7 @@ spec:
                 configMapKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-config
                   key: authTokenUrl
+            {{- end }}
             - name: IDENTITY_SERVICE_HOST
               valueFrom:
                 configMapKeyRef:
@@ -135,3 +137,8 @@ spec:
                 configMapKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-config
                   key: identityServicePort
+            - name: AUTH_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "inteli-api.fullname" . }}-config
+                  key: authType

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -8,6 +8,7 @@ config:
   identityServiceHost: localhost
   identityServicePort: 80
   auth:
+    type: NONE
     jwksUri: https://inteli.eu.auth0.com/.well-known/jwks.json
     audience: inteli-dev
     issuer: https://inteli.eu.auth0.com/
@@ -26,7 +27,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.20.3'
+  tag: 'v1.22.0'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.20.3",
+  "version": "1.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.20.3",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
     "coverage": "LOG_LEVEL=fatal NODE_ENV=development nyc mocha --recursive ./test/integration --timeout 60000 --slow 20000 --exit",
-    "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development nyc --no-clean npm run test && nyc --no-clean npm run test:jwt && nyc merge .nyc_output --timeout 60000 --slow 20000 --exit",
     "migrate": "knex migrate:latest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.20.3",
+  "version": "1.22.0",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {
     "db:migrate": "npx knex migrate:latest --env test",
     "test": "NODE_ENV=test mocha --config ./test/mocharc.js ./test",
     "test:unit": "NODE_ENV=test mocha --config ./test/mocharc.js ./app",
+    "test:jwt": "NODE_ENV=test AUTH_TYPE=JWT mocha --config ./test/mocharc.js ./test",
     "lint": "eslint .",
     "depcheck": "depcheck",
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
-    "coverage": "nyc npm run test",
+    "coverage": "LOG_LEVEL=fatal NODE_ENV=development nyc mocha --recursive ./test/integration --timeout 60000 --slow 20000 --exit",
+    "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development nyc --no-clean npm run test && nyc --no-clean npm run test:jwt && nyc merge .nyc_output --timeout 60000 --slow 20000 --exit",
     "migrate": "knex migrate:latest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "NODE_ENV=production node app/index.js",
     "dev": "NODE_ENV=development nodemon app/index.js | pino-colada",
     "coverage": "LOG_LEVEL=fatal NODE_ENV=development nyc mocha --recursive ./test/integration --timeout 60000 --slow 20000 --exit",
+    "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development docker compose up -d && nyc --no-clean npm run test && AUTH_TYPE=JWT docker compose up -d && nyc --no-clean npm run test:jwt && docker compose down && nyc merge .nyc_output --timeout 60000 --slow 20000 --exit ",
     "migrate": "knex migrate:latest"
   },
   "repository": {

--- a/test/integration/attachment.test.js
+++ b/test/integration/attachment.test.js
@@ -1,7 +1,7 @@
 const createJWKSMock = require('mock-jwks').default
 const { describe, before, it, after } = require('mocha')
 const { expect } = require('chai')
-const seed = require('../seeds/recipes')
+const { seed, cleanup } = require('../seeds/recipes')
 
 const { createHttpServer } = require('../../app/server')
 const { AUTH_ISSUER, AUTH_AUDIENCE, FILE_UPLOAD_SIZE_LIMIT_BYTES, AUTH_TYPE } = require('../../app/env')
@@ -33,6 +33,7 @@ describeAuthOnly('attachments - authenticated', function () {
   })
 
   after(async function () {
+    await cleanup()
     await jwksMock.stop()
   })
 
@@ -101,19 +102,19 @@ describeAuthOnly('attachments - authenticated', function () {
     expect(response.status).to.equal(200)
   })
 
-  it('should return 406 when rquesting json from the octet route', async function () {
+  it('should return 406 when requesting json from the octet route', async function () {
     const attachment = '00000000-0000-1000-8000-000000000001'
     const response = await getAttachmentRouteJSON(attachment, app, authToken)
     expect(response.status).to.equal(406)
   })
 
-  it('should return 404 when rquesting incorrect ID', async function () {
+  it('should return 404 when requesting incorrect ID', async function () {
     const attachment = '00000000-0000-1000-8000-000000000002'
     const response = await getAttachmentRouteOctet(attachment, app, authToken)
     expect(response.status).to.equal(404)
   })
 
-  it('should return 400 when rquesting incorrect ID', async function () {
+  it('should return 400 when requesting invalid ID', async function () {
     const attachment = 'invalid'
     const response = await getAttachmentRouteOctet(attachment, app, authToken)
     expect(response.status).to.equal(400)

--- a/test/integration/auth.test.js
+++ b/test/integration/auth.test.js
@@ -6,8 +6,11 @@ const { createHttpServer } = require('../../app/server')
 const { postAttachment } = require('../helper/routeHelper')
 const { getAuthToken } = require('../helper/auth')
 const { lastTokenId } = require('../../app/api-v1/services/dscpApiService')
+const { AUTH_TYPE } = require('../../app/env')
 
-describe('authentication', function () {
+const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
+
+describeAuthOnly('authentication', function () {
   let app
 
   before(async function () {

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -163,16 +163,5 @@ describeNoAuthOnly('order - no auth', function () {
       expect(response.body.items).to.contain('10000000-0000-1000-8000-000000000000')
       expect(response.status).to.equal(201)
     })
-
-    test('POST Order with more than one item - 201', async function () {
-      const newProject = {
-        supplier: 'valid-1',
-        requiredBy: new Date().toISOString(),
-        items: ['10000000-0000-1000-8000-000000000000', '10000000-0000-1000-8000-000000000000'],
-      }
-
-      const response = await postOrderRoute(newProject, app, null)
-      expect(response.status).to.equal(201)
-    })
   })
 })

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -6,9 +6,12 @@ const { createHttpServer } = require('../../app/server')
 const { postOrderRoute } = require('../helper/routeHelper')
 const { setupIdentityMock } = require('../helper/identityHelper')
 const { seed, cleanup } = require('../seeds/orders')
-const { AUTH_ISSUER, AUTH_AUDIENCE } = require('../../app/env')
+const { AUTH_ISSUER, AUTH_AUDIENCE, AUTH_TYPE } = require('../../app/env')
 
-describe('order', function () {
+const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
+const describeNoAuthOnly = AUTH_TYPE === 'NONE' ? describe : describe.skip
+
+describeAuthOnly('order - authenticated', function () {
   describe('valid order', function () {
     this.timeout(3000)
     let app
@@ -128,6 +131,48 @@ describe('order', function () {
 
       const response = await postOrderRoute(newProject, app, authToken)
       expect(response.status).to.equal(400)
+    })
+  })
+})
+
+describeNoAuthOnly('order - no auth', function () {
+  describe('valid order', function () {
+    this.timeout(3000)
+    let app
+
+    before(async function () {
+      await seed()
+      app = await createHttpServer()
+    })
+
+    after(async function () {
+      await cleanup()
+    })
+
+    setupIdentityMock()
+
+    test('POST Order - Check ID & Manufacturer', async function () {
+      const newOrder = {
+        supplier: 'valid-1',
+        requiredBy: new Date().toISOString(),
+        items: ['10000000-0000-1000-8000-000000000000'],
+      }
+      const response = await postOrderRoute(newOrder, app, null)
+      expect(response.body.supplier).to.equal('valid-1')
+      expect(response.body.purchaser).to.equal('valid-2')
+      expect(response.body.items).to.contain('10000000-0000-1000-8000-000000000000')
+      expect(response.status).to.equal(201)
+    })
+
+    test('POST Order with more than one item - 201', async function () {
+      const newProject = {
+        supplier: 'valid-1',
+        requiredBy: new Date().toISOString(),
+        items: ['10000000-0000-1000-8000-000000000000', '10000000-0000-1000-8000-000000000000'],
+      }
+
+      const response = await postOrderRoute(newProject, app, null)
+      expect(response.status).to.equal(201)
     })
   })
 })

--- a/test/integration/recipe.test.js
+++ b/test/integration/recipe.test.js
@@ -151,6 +151,7 @@ describeAuthOnly('recipes - authenticated', function () {
     setupIdentityMock()
 
     after(async function () {
+      await cleanup()
       await jwksMock.stop()
     })
 
@@ -206,52 +207,16 @@ describeAuthOnly('recipes - authenticated', function () {
 })
 
 describeNoAuthOnly('recipes - no auth', function () {
-  describe('POST recipes', function () {
-    this.timeout(5000)
+  describe('POST + GET recipes', function () {
     let app
 
-    before(async function () {
+    before(async () => {
       await seed()
       app = await createHttpServer()
     })
 
     after(async function () {
       await cleanup()
-    })
-
-    setupIdentityMock()
-
-    it('should accept valid body', async function () {
-      const newRecipe = {
-        externalId: 'foobar3000',
-        name: 'foobar3000',
-        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
-        material: 'foobar3000',
-        alloy: 'foobar3000',
-        price: 'foobar3000',
-        requiredCerts: [{ description: 'foobar3000' }],
-        supplier: 'valid-1',
-      }
-
-      const response = await postRecipeRoute(newRecipe, app, null)
-      expect(response.status).to.equal(201)
-      const { id: responseId, ...responseRest } = response.body
-      expect(responseId).to.match(
-        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ABab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/
-      )
-      expect(responseRest).to.deep.equal({
-        ...newRecipe,
-        owner: 'valid-2',
-      })
-    })
-  })
-
-  describe('GET recipes', function () {
-    let app
-
-    before(async () => {
-      await seed()
-      app = await createHttpServer()
     })
 
     setupIdentityMock()

--- a/test/integration/recipe.test.js
+++ b/test/integration/recipe.test.js
@@ -3,15 +3,18 @@ const { describe, before, it } = require('mocha')
 const { expect } = require('chai')
 
 const { createHttpServer } = require('../../app/server')
-const seed = require('../seeds/recipes')
+const { seed, cleanup } = require('../seeds/recipes')
 const { postRecipeRoute, getRecipeRoute, getRecipeByIdRoute } = require('../helper/routeHelper')
 const { setupIdentityMock } = require('../helper/identityHelper')
 const recipesFixture = require('../fixtures/recipes')
-const { AUTH_ISSUER, AUTH_AUDIENCE } = require('../../app/env')
+const { AUTH_ISSUER, AUTH_AUDIENCE, AUTH_TYPE } = require('../../app/env')
 
 const logger = require('../../app/utils/Logger')
 
-describe('Recipes', function () {
+const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
+const describeNoAuthOnly = AUTH_TYPE === 'NONE' ? describe : describe.skip
+
+describeAuthOnly('recipes - authenticated', function () {
   describe('POST recipes', function () {
     this.timeout(5000)
     let app
@@ -32,6 +35,7 @@ describe('Recipes', function () {
     setupIdentityMock()
 
     after(async function () {
+      await cleanup()
       await jwksMock.stop()
     })
 
@@ -197,6 +201,98 @@ describe('Recipes', function () {
     it('should return a 400 with an incorrect ID format', async function () {
       const response = await getRecipeByIdRoute(app, '63248be7b884', authToken)
       expect(response.status).to.equal(400)
+    })
+  })
+})
+
+describeNoAuthOnly('recipes - no auth', function () {
+  describe('POST recipes', function () {
+    this.timeout(5000)
+    let app
+
+    before(async function () {
+      await seed()
+      app = await createHttpServer()
+    })
+
+    after(async function () {
+      await cleanup()
+    })
+
+    setupIdentityMock()
+
+    it('should accept valid body', async function () {
+      const newRecipe = {
+        externalId: 'foobar3000',
+        name: 'foobar3000',
+        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
+        material: 'foobar3000',
+        alloy: 'foobar3000',
+        price: 'foobar3000',
+        requiredCerts: [{ description: 'foobar3000' }],
+        supplier: 'valid-1',
+      }
+
+      const response = await postRecipeRoute(newRecipe, app, null)
+      expect(response.status).to.equal(201)
+      const { id: responseId, ...responseRest } = response.body
+      expect(responseId).to.match(
+        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ABab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/
+      )
+      expect(responseRest).to.deep.equal({
+        ...newRecipe,
+        owner: 'valid-2',
+      })
+    })
+  })
+
+  describe('GET recipes', function () {
+    let app
+
+    before(async () => {
+      await seed()
+      app = await createHttpServer()
+    })
+
+    setupIdentityMock()
+
+    it('should get recipe by id - 200', async function () {
+      const newRecipe = {
+        externalId: 'foobar3000',
+        name: 'foobar3000',
+        imageAttachmentId: '00000000-0000-1000-8000-000000000000',
+        material: 'foobar3000',
+        alloy: 'foobar3000',
+        price: 'foobar3000',
+        requiredCerts: [{ description: 'foobar3000' }],
+        supplier: 'valid-1',
+      }
+
+      const recipe = await postRecipeRoute(newRecipe, app, null)
+      const response = await getRecipeByIdRoute(app, recipe.body.id, null)
+      expect(response.status).to.equal(200)
+    })
+
+    it('should get recipe list - 200', async function () {
+      const recipes = await Promise.all(
+        recipesFixture.map(async (newRecipe) => {
+          const { body: recipe } = await postRecipeRoute(newRecipe, app, null)
+          return recipe
+        })
+      )
+
+      const { status, body } = await getRecipeRoute(app, null)
+      expect(status).to.equal(200)
+      expect(body).to.be.an('array')
+      const ids = recipes.map(({ id }) => id)
+      body
+        .filter(({ id }) => ids.includes(id))
+        .map((recipe, i) => {
+          expect(recipes[i]).to.deep.contains({
+            ...recipe,
+            owner: 'valid-2',
+          })
+        })
     })
   })
 })

--- a/test/seeds/orders.js
+++ b/test/seeds/orders.js
@@ -9,7 +9,6 @@ const cleanup = async () => {
 const seed = async () => {
   await cleanup()
 
-  // create thing types
   await client('attachments').insert([
     {
       id: '00000000-0000-1000-8000-000000000000',

--- a/test/seeds/recipe-creation.js
+++ b/test/seeds/recipe-creation.js
@@ -8,8 +8,8 @@ const cleanup = async () => {
 }
 const attachmentId = '10000000-0000-1000-8000-000000000000'
 
-module.exports = async () => {
-  await cleanup() // no need to export, it call it anyway...
+const seed = async () => {
+  await cleanup()
 
   await db.client('attachments').insert([
     {
@@ -52,4 +52,9 @@ module.exports = async () => {
     status: 'Submitted',
     created_at: '2021-10-10',
   })
+}
+
+module.exports = {
+  cleanup,
+  seed,
 }

--- a/test/seeds/recipes.js
+++ b/test/seeds/recipes.js
@@ -7,8 +7,8 @@ const cleanup = async () => {
 
 const attachmentId = '00000000-0000-1000-8000-000000000000'
 
-module.exports = async () => {
-  await cleanup() // no need to export, it call it anyway...
+const seed = async () => {
+  await cleanup()
 
   await client('attachments').insert([
     {
@@ -34,4 +34,9 @@ module.exports = async () => {
     supplier: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
     owner: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
   })
+}
+
+module.exports = {
+  cleanup,
+  seed,
 }


### PR DESCRIPTION
Make it so the service can be run with/without authentication based on an env.

- [x] `AUTH_TYPE` of dependencies set with envs in `docker-compose` 
- [x] add `AUTH_TYPE` env + readme + helm
- [x] make jwt verification, OpenAPI spec, security handlers and other AUTH envs conditional on `AUTH_TYPE`
- [x] split tests into auth by JWT, no auth and both
- [x] use matrix to run both in GitHub CI  
- [x] new tests for no auth