### PR TITLE
Remove manufacturer from API docs

### DIFF
--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -170,8 +170,8 @@ const apiDoc = {
               allOf: [{ $ref: '#/components/schemas/ObjectReference' }],
             },
           },
-          manufacturer: {
-            description: 'Name of the manufacturer who ran the build. This information is not stored directly on-chain',
+          supplier: {
+            description: 'Name of the supplier who ran the build. This information is not stored directly on-chain',
             type: 'string',
             maxLength: 255,
           },
@@ -228,9 +228,8 @@ const apiDoc = {
             description: 'id of the build that produces/produced this part',
             allOf: [{ $ref: '#/components/schemas/ObjectReference' }],
           },
-          manufacturer: {
-            description:
-              'Name of the manufacturer who created the part. This information is not stored directly on-chain',
+          supplier: {
+            description: 'Name of the suppler who created the part. This information is not stored directly on-chain',
             type: 'string',
             maxLength: 255,
           },
@@ -257,7 +256,7 @@ const apiDoc = {
         properties: {
           supplier: {
             description:
-              'Name of the manufacturer who will supply parts from this purchase-order. This information is not stored directly on-chain',
+              'Name of the supplier who will supply parts from this purchase-order. This information is not stored directly on-chain',
             type: 'string',
             maxLength: 255,
           },

--- a/app/api-v1/services/orderService.js
+++ b/app/api-v1/services/orderService.js
@@ -4,7 +4,7 @@ const { IncorrectSupplierError, RecipeDoesNotExistError } = require('../../utils
 async function postOrder(reqBody) {
   // Will add a get function at a later date to check for duplication
 
-  // This section checks if the order manufacturer does not match the supplier
+  // This section checks if the order supplier does not match the supplier
   const uniqueRecipeIDs = [...new Set(reqBody.items)]
 
   const recipes = await getRecipeByIDs(uniqueRecipeIDs)

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.21.0'
+appVersion: '1.21.1'
 description: A Helm chart for inteli-api
-version: '1.21.0'
+version: '1.21.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -26,7 +26,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.21.0'
+  tag: 'v1.21.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -45,7 +45,7 @@ describe('order', function () {
       expect(response.body.supplier).deep.equal(newOrder.supplier)
     })
 
-    test('POST Order - Check ID & Manufacturer', async function () {
+    test('POST Order - Check ID & Supplier', async function () {
       const newOrder = {
         supplier: 'valid-1',
         requiredBy: new Date().toISOString(),


### PR DESCRIPTION
Removes the term `manufacturer` where appropriate in the API-Docs as well as updating a few comments.
