### PR TITLE
validate all json responses

### DIFF
--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -12,21 +12,31 @@ const apiDoc = {
     },
   ],
   components: {
-    responses: {
+    schemas: {
+      Error: {
+        description: 'An error occurred',
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+          },
+        },
+      },
       NotFoundError: {
         description: 'This resource cannot be found',
+        type: 'object',
+        allOf: [{ $ref: '#/components/schemas/Error' }],
       },
       BadRequestError: {
         description: 'The request is invalid',
+        type: 'object',
+        allOf: [{ $ref: '#/components/schemas/Error' }],
       },
       UnauthorizedError: {
         description: 'Access token is missing or invalid',
+        type: 'object',
+        allOf: [{ $ref: '#/components/schemas/Error' }],
       },
-      Error: {
-        description: 'An error occurred',
-      },
-    },
-    schemas: {
       NewRecipe: {
         type: 'object',
         properties: {

--- a/app/api-v1/routes/attachment.js
+++ b/app/api-v1/routes/attachment.js
@@ -22,107 +22,93 @@ module.exports = function (attachmentService) {
             },
           },
         },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
-              },
-            },
-          },
-        },
       },
       security: [{ bearerAuth: [] }],
       tags: ['attachment'],
     }),
-    POST: async function (req, res) {
-      if (req.headers['content-type'] === 'application/json') {
-        logger.info('JSON attachment upload: %j', req.body)
-        const buffer = Buffer.from(JSON.stringify(req.body))
-        const [result] = await attachmentService.createAttachment('json', buffer)
-        res.status(201).json({ ...result, size: buffer.length })
-        return
-      }
+    POST: buildValidatedJsonHandler(
+      async function (req) {
+        if (req.headers['content-type'] === 'application/json') {
+          logger.info('JSON attachment upload: %j', req.body)
+          const buffer = Buffer.from(JSON.stringify(req.body))
+          const [result] = await attachmentService.createAttachment('json', buffer)
+          return {
+            status: 201,
+            response: { ...result, size: buffer.length },
+          }
+        }
 
-      logger.info('File attachment upload: %s', req.file)
+        logger.info('File attachment upload: %s', req.file)
 
-      if (!req.file) {
-        throw new BadRequestError('No file uploaded')
-      }
+        if (!req.file) {
+          throw new BadRequestError('No file uploaded')
+        }
 
-      const [result] = await attachmentService.createAttachmentFromFile(req.file)
-      res.status(201).json({ ...result, size: req.file.size })
-    },
-  }
-
-  doc.POST.apiDoc = {
-    summary: 'Create Attachment',
-    requestBody: {
-      content: {
-        'multipart/form-data': {
-          schema: {
-            type: 'object',
-            properties: {
-              file: {
-                type: 'string',
-                format: 'binary',
-              },
-            },
-          },
-        },
-        'application/json': {
-          schema: {
-            anyOf: [
-              {
+        const [result] = await attachmentService.createAttachmentFromFile(req.file)
+        return {
+          status: 201,
+          response: { ...result, size: req.file.size },
+        }
+      },
+      {
+        summary: 'Create Attachment',
+        requestBody: {
+          content: {
+            'multipart/form-data': {
+              schema: {
                 type: 'object',
-                properties: {},
-                additionalProperties: true,
+                properties: {
+                  file: {
+                    type: 'string',
+                    format: 'binary',
+                  },
+                },
               },
-              {
-                type: 'array',
-                items: {},
+            },
+            'application/json': {
+              schema: {
+                anyOf: [
+                  {
+                    type: 'object',
+                    properties: {},
+                    additionalProperties: true,
+                  },
+                  {
+                    type: 'array',
+                    items: {},
+                  },
+                ],
               },
-            ],
-          },
-          example: {},
-        },
-      },
-    },
-    responses: {
-      201: {
-        description: 'Attachment Created',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/AttachmentEntry',
+              example: {},
             },
           },
         },
-      },
-      400: {
-        description: 'Invalid request',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/BadRequestError',
+        responses: {
+          201: {
+            description: 'Attachment Created',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/AttachmentEntry',
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Invalid request',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/BadRequestError',
+                },
+              },
             },
           },
         },
-      },
-      default: {
-        description: 'An error occurred',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/Error',
-            },
-          },
-        },
-      },
-    },
-    security: [{ bearerAuth: [] }],
-    tags: ['attachment'],
+        security: [{ bearerAuth: [] }],
+        tags: ['attachment'],
+      }
+    ),
   }
 
   return doc

--- a/app/api-v1/routes/attachment/{id}.js
+++ b/app/api-v1/routes/attachment/{id}.js
@@ -98,16 +98,6 @@ module.exports = function (attachmentService) {
           },
         },
       },
-      default: {
-        description: 'An error occurred',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/Error',
-            },
-          },
-        },
-      },
     },
     security: [{ bearerAuth: [] }],
     tags: ['attachment'],

--- a/app/api-v1/routes/build.js
+++ b/app/api-v1/routes/build.js
@@ -20,16 +20,6 @@ module.exports = function () {
             },
           },
         },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
-              },
-            },
-          },
-        },
       },
       security: [{ bearerAuth: [] }],
       tags: ['build'],
@@ -61,17 +51,7 @@ module.exports = function () {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}.js
+++ b/app/api-v1/routes/build/{id}.js
@@ -37,17 +37,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/completion.js
+++ b/app/api-v1/routes/build/{id}/completion.js
@@ -37,17 +37,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/completion/{completionId}.js
+++ b/app/api-v1/routes/build/{id}/completion/{completionId}.js
@@ -44,17 +44,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/progress-update.js
+++ b/app/api-v1/routes/build/{id}/progress-update.js
@@ -37,17 +37,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/progress-update/{updateId}.js
+++ b/app/api-v1/routes/build/{id}/progress-update/{updateId}.js
@@ -44,17 +44,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/schedule.js
+++ b/app/api-v1/routes/build/{id}/schedule.js
@@ -37,17 +37,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/schedule/{scheduleId}.js
+++ b/app/api-v1/routes/build/{id}/schedule/{scheduleId}.js
@@ -44,17 +44,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/start.js
+++ b/app/api-v1/routes/build/{id}/start.js
@@ -37,17 +37,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/build/{id}/start/{startId}.js
+++ b/app/api-v1/routes/build/{id}/start/{startId}.js
@@ -44,17 +44,7 @@ module.exports = function (buildService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/order.js
+++ b/app/api-v1/routes/order.js
@@ -21,89 +21,73 @@ module.exports = function (orderService, identityService) {
             },
           },
         },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
-              },
-            },
-          },
-        },
       },
       security: [{ bearerAuth: [] }],
       tags: ['order'],
     }),
-    POST: async function (req, res) {
-      if (!req.body) {
-        throw new BadRequestError({ message: 'No body uploaded', req })
+    POST: buildValidatedJsonHandler(
+      async function (req) {
+        if (!req.body) {
+          throw new BadRequestError({ message: 'No body uploaded', req })
+        }
+
+        const { address: supplierAddress } = await identityService.getMemberByAlias(req, req.body.supplier)
+        const selfAddress = await identityService.getMemberBySelf(req)
+        const { alias: selfAlias } = await identityService.getMemberByAlias(req, selfAddress)
+
+        const { statusCode, result } = await orderService.postOrder({
+          ...req.body,
+          supplier: supplierAddress,
+          purchaserAddress: selfAlias,
+        })
+
+        return {
+          status: statusCode,
+          response: {
+            id: result.id,
+            status: 'Created',
+            purchaser: selfAlias,
+            ...req.body,
+          },
+        }
+      },
+      {
+        summary: 'Create Purchase Order',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/NewOrder',
+              },
+            },
+          },
+        },
+        responses: {
+          201: {
+            description: 'Purchase Order Created',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Order',
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Invalid request',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/BadRequestError',
+                },
+              },
+            },
+          },
+        },
+        security: [{ bearerAuth: [] }],
+        tags: ['order'],
       }
-
-      const { address: supplierAddress } = await identityService.getMemberByAlias(req, req.body.supplier)
-      const selfAddress = await identityService.getMemberBySelf(req)
-      const { alias: selfAlias } = await identityService.getMemberByAlias(req, selfAddress)
-
-      const { statusCode, result } = await orderService.postOrder({
-        ...req.body,
-        supplier: supplierAddress,
-        purchaserAddress: selfAlias,
-      })
-
-      return res.status(statusCode).json({
-        id: result.id,
-        status: 'Created',
-        purchaser: selfAlias,
-        ...req.body,
-      })
-    },
-  }
-
-  doc.POST.apiDoc = {
-    summary: 'Create Purchase Order',
-    requestBody: {
-      content: {
-        'application/json': {
-          schema: {
-            $ref: '#/components/schemas/NewOrder',
-          },
-        },
-      },
-    },
-    responses: {
-      201: {
-        description: 'Purchase Order Created',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/schemas/Order',
-            },
-          },
-        },
-      },
-      400: {
-        description: 'Invalid request',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/BadRequestError',
-            },
-          },
-        },
-      },
-      default: {
-        description: 'An error occurred',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/Error',
-            },
-          },
-        },
-      },
-    },
-    security: [{ bearerAuth: [] }],
-    tags: ['order'],
+    ),
   }
 
   return doc

--- a/app/api-v1/routes/order/{id}.js
+++ b/app/api-v1/routes/order/{id}.js
@@ -37,17 +37,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/acceptance.js
+++ b/app/api-v1/routes/order/{id}/acceptance.js
@@ -37,17 +37,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/acceptance/{acceptanceId}.js
+++ b/app/api-v1/routes/order/{id}/acceptance/{acceptanceId}.js
@@ -44,17 +44,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/amendment.js
+++ b/app/api-v1/routes/order/{id}/amendment.js
@@ -37,17 +37,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/amendment/{amendmentId}.js
+++ b/app/api-v1/routes/order/{id}/amendment/{amendmentId}.js
@@ -44,17 +44,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/rejection.js
+++ b/app/api-v1/routes/order/{id}/rejection.js
@@ -37,17 +37,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -94,17 +84,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/rejection/{rejectionId}.js
+++ b/app/api-v1/routes/order/{id}/rejection/{rejectionId}.js
@@ -44,17 +44,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/submission.js
+++ b/app/api-v1/routes/order/{id}/submission.js
@@ -37,17 +37,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -94,17 +84,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/order/{id}/submission/{submissionId}.js
+++ b/app/api-v1/routes/order/{id}/submission/{submissionId}.js
@@ -44,17 +44,7 @@ module.exports = function (orderService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/part.js
+++ b/app/api-v1/routes/part.js
@@ -20,16 +20,6 @@ module.exports = function () {
             },
           },
         },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
-              },
-            },
-          },
-        },
       },
       security: [{ bearerAuth: [] }],
       tags: ['part'],

--- a/app/api-v1/routes/part/{id}.js
+++ b/app/api-v1/routes/part/{id}.js
@@ -37,17 +37,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/part/{id}/certification.js
+++ b/app/api-v1/routes/part/{id}/certification.js
@@ -37,17 +37,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -94,17 +84,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/part/{id}/certification/{certificationId}.js
+++ b/app/api-v1/routes/part/{id}/certification/{certificationId}.js
@@ -44,17 +44,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/part/{id}/metadata-update.js
+++ b/app/api-v1/routes/part/{id}/metadata-update.js
@@ -37,17 +37,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/part/{id}/metadata-update/{updateId}.js
+++ b/app/api-v1/routes/part/{id}/metadata-update/{updateId}.js
@@ -44,17 +44,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/part/{id}/order-assignment.js
+++ b/app/api-v1/routes/part/{id}/order-assignment.js
@@ -37,17 +37,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -95,17 +85,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/BadRequestError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/BadRequestError',
               },
             },
           },

--- a/app/api-v1/routes/part/{id}/order-assignment/{assignmentId}.js
+++ b/app/api-v1/routes/part/{id}/order-assignment/{assignmentId}.js
@@ -44,17 +44,7 @@ module.exports = function (partService) {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },

--- a/app/api-v1/routes/recipe.js
+++ b/app/api-v1/routes/recipe.js
@@ -46,16 +46,6 @@ module.exports = function (recipeService, identityService) {
               },
             },
           },
-          default: {
-            description: 'An error occurred',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/responses/Error',
-                },
-              },
-            },
-          },
         },
         security: [{ bearerAuth: [] }],
         tags: ['recipe'],
@@ -123,17 +113,7 @@ module.exports = function (recipeService, identityService) {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/responses/BadRequestError',
-                },
-              },
-            },
-          },
-          default: {
-            description: 'An error occurred',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/responses/Error',
+                  $ref: '#/components/schemas/BadRequestError',
                 },
               },
             },

--- a/app/api-v1/routes/recipe/{id}.js
+++ b/app/api-v1/routes/recipe/{id}.js
@@ -1,62 +1,71 @@
+const { buildValidatedJsonHandler } = require('../../../utils/routeResponseValidator')
+
 // eslint-disable-next-line no-unused-vars
-module.exports = function (recipeService) {
+module.exports = function (recipeService, identityService) {
   const doc = {
-    GET: async function (req, res) {
-      const { id } = req.params
-      const result = await recipeService.getRecipeByID(id)
+    GET: buildValidatedJsonHandler(
+      async function (req) {
+        const { id } = req.params
+        const result = await recipeService.getRecipeByID(id)
+        const { alias: supplierAlias } = await identityService.getMemberByAddress(req, result.supplier)
+        const { alias: ownerAlias } = await identityService.getMemberByAddress(req, result.owner)
 
-      return res.status(200).json(result)
-    },
-  }
-
-  doc.GET.apiDoc = {
-    summary: 'Get Recipe',
-    parameters: [
+        return {
+          status: 200,
+          response: {
+            id: result.id,
+            externalId: result.external_id,
+            name: result.name,
+            imageAttachmentId: result.image_attachment_id,
+            material: result.material,
+            alloy: result.alloy,
+            price: result.price,
+            requiredCerts: result.required_certs,
+            supplier: supplierAlias,
+            owner: ownerAlias,
+          },
+        }
+      },
       {
-        description: 'Id of the recipe to get',
-        in: 'path',
-        required: true,
-        name: 'id',
-        allowEmptyValue: false,
-        schema: {
-          $ref: '#/components/schemas/ObjectReference',
-        },
-      },
-    ],
-    responses: {
-      200: {
-        description: 'Return Recipe',
-        content: {
-          'application/json': {
+        summary: 'Get Recipe',
+        parameters: [
+          {
+            description: 'Id of the recipe to get',
+            in: 'path',
+            required: true,
+            name: 'id',
+            allowEmptyValue: false,
             schema: {
-              $ref: '#/components/schemas/Recipe',
+              $ref: '#/components/schemas/ObjectReference',
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Return Recipe',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Recipe',
+                },
+              },
+            },
+          },
+          404: {
+            description: 'Recipe not found',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/NotFoundError',
+                },
+              },
             },
           },
         },
-      },
-      404: {
-        description: 'Recipe not found',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/NotFoundError',
-            },
-          },
-        },
-      },
-      default: {
-        description: 'An error occurred',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/Error',
-            },
-          },
-        },
-      },
-    },
-    security: [{ bearerAuth: [] }],
-    tags: ['recipe'],
+        security: [{ bearerAuth: [] }],
+        tags: ['recipe'],
+      }
+    ),
   }
 
   return doc

--- a/app/api-v1/routes/recipe/{id}/creation.js
+++ b/app/api-v1/routes/recipe/{id}/creation.js
@@ -36,17 +36,7 @@ module.exports = function () {
           content: {
             'application/json': {
               schema: {
-                $ref: '#/components/responses/NotFoundError',
-              },
-            },
-          },
-        },
-        default: {
-          description: 'An error occurred',
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/responses/Error',
+                $ref: '#/components/schemas/NotFoundError',
               },
             },
           },
@@ -54,69 +44,60 @@ module.exports = function () {
       },
       tags: ['recipe'],
     }),
-    POST: async function (req, res) {
-      const { status, ...body } = await transaction.create(req)
-      res.status(status).send(body)
-    },
-  }
-
-  doc.POST.apiDoc = {
-    summary: 'Create Recipe Creation Action',
-    parameters: [
+    POST: buildValidatedJsonHandler(
+      async function (req) {
+        const { status, ...body } = await transaction.create(req)
+        return { status, response: body }
+      },
       {
-        description: 'Id of the recipe',
-        in: 'path',
-        required: true,
-        name: 'id',
-        allowEmptyValue: false,
-        schema: {
-          $ref: '#/components/schemas/ObjectReference',
-        },
-      },
-    ],
-    requestBody: {
-      content: {
-        'application/json': {
-          schema: {
-            $ref: '#/components/schemas/NewRecipeCreation',
-          },
-        },
-      },
-    },
-    responses: {
-      201: {
-        description: 'Recipe Creation Created',
-        content: {
-          'application/json': {
+        summary: 'Create Recipe Creation Action',
+        parameters: [
+          {
+            description: 'Id of the recipe',
+            in: 'path',
+            required: true,
+            name: 'id',
+            allowEmptyValue: false,
             schema: {
-              $ref: '#/components/schemas/RecipeCreation',
+              $ref: '#/components/schemas/ObjectReference',
+            },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/NewRecipeCreation',
+              },
             },
           },
         },
-      },
-      400: {
-        description: 'Invalid request',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/BadRequestError',
+        responses: {
+          201: {
+            description: 'Recipe Creation Created',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RecipeCreation',
+                },
+              },
+            },
+          },
+          400: {
+            description: 'Invalid request',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/BadRequestError',
+                },
+              },
             },
           },
         },
-      },
-      default: {
-        description: 'An error occurred',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/Error',
-            },
-          },
-        },
-      },
-    },
-    security: [{ bearerAuth: [] }],
-    tags: ['recipe'],
+        security: [{ bearerAuth: [] }],
+        tags: ['recipe'],
+      }
+    ),
   }
 
   return doc

--- a/app/api-v1/routes/recipe/{id}/creation/{creationId}.js
+++ b/app/api-v1/routes/recipe/{id}/creation/{creationId}.js
@@ -1,72 +1,64 @@
 const { transaction } = require('../../../../controllers/Recipe')
+const { buildValidatedJsonHandler } = require('../../../../../utils/routeResponseValidator')
 
 // eslint-disable-next-line no-unused-vars
 module.exports = function (recipeService) {
   const doc = {
-    GET: async function (req, res) {
-      const { status, ...body } = await transaction.get(req)
-      res.status(status).send(body)
-    },
-  }
-
-  doc.GET.apiDoc = {
-    summary: 'Get Recipe Creation Action',
-    parameters: [
-      {
-        description: 'Id of the recipe',
-        in: 'path',
-        required: true,
-        name: 'id',
-        allowEmptyValue: false,
-        schema: {
-          $ref: '#/components/schemas/ObjectReference',
-        },
+    GET: buildValidatedJsonHandler(
+      async function (req) {
+        const { status, ...body } = await transaction.get(req)
+        return { status, response: body }
       },
       {
-        description: 'Id of the recipe creation action',
-        in: 'path',
-        required: true,
-        name: 'creationId',
-        allowEmptyValue: false,
-        schema: {
-          $ref: '#/components/schemas/ObjectReference',
-        },
-      },
-    ],
-    responses: {
-      200: {
-        description: 'Return Recipe Creation Action',
-        content: {
-          'application/json': {
+        summary: 'Get Recipe Creation Action',
+        parameters: [
+          {
+            description: 'Id of the recipe',
+            in: 'path',
+            required: true,
+            name: 'id',
+            allowEmptyValue: false,
             schema: {
-              $ref: '#/components/schemas/RecipeCreation',
+              $ref: '#/components/schemas/ObjectReference',
+            },
+          },
+          {
+            description: 'Id of the recipe creation action',
+            in: 'path',
+            required: true,
+            name: 'creationId',
+            allowEmptyValue: false,
+            schema: {
+              $ref: '#/components/schemas/ObjectReference',
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Return Recipe Creation Action',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RecipeCreation',
+                },
+              },
+            },
+          },
+          404: {
+            description: 'Recipe Creation Action not found',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/NotFoundError',
+                },
+              },
             },
           },
         },
-      },
-      404: {
-        description: 'Recipe Creation Action not found',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/NotFoundError',
-            },
-          },
-        },
-      },
-      default: {
-        description: 'An error occurred',
-        content: {
-          'application/json': {
-            schema: {
-              $ref: '#/components/responses/Error',
-            },
-          },
-        },
-      },
-    },
-    security: [{ bearerAuth: [] }],
-    tags: ['recipe'],
+        security: [{ bearerAuth: [] }],
+        tags: ['recipe'],
+      }
+    ),
   }
 
   return doc

--- a/app/utils/__tests__/routeResponseValidator.test.js
+++ b/app/utils/__tests__/routeResponseValidator.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const validatorMod = require('openapi-response-validator')
 
-const { buildValidatedJsonHandler } = require('../routeResponseValidator')
+const { buildValidatedJsonHandler, commonResponses } = require('../routeResponseValidator')
 const { exampleDoc } = require('./response_validator_fixtures')
 const commonApiDoc = require('../../api-v1/api-doc')
 
@@ -52,8 +52,15 @@ describe('buildValidatedJsonHandler', () => {
     expect(context.handler).to.be.a('function')
   })
 
-  it('returns function with apiDoc', () => {
-    expect(context.handler.apiDoc).to.equal(exampleDoc)
+  it('returns function with apiDoc + common responses', () => {
+    const expectedResponses = {
+      ...commonResponses,
+      ...exampleDoc.responses,
+    }
+    expect(context.handler.apiDoc).to.deep.equal({
+      ...exampleDoc,
+      responses: expectedResponses,
+    })
   })
 
   it('builds a validator', () => {
@@ -64,7 +71,13 @@ describe('buildValidatedJsonHandler', () => {
   it('builds a validator with responses and components', () => {
     const stub = context.stubs.ctor
     expect(stub.firstCall.args).to.deep.equal([
-      { responses: exampleDoc.responses, components: commonApiDoc.components },
+      {
+        responses: {
+          ...commonResponses,
+          ...exampleDoc.responses,
+        },
+        components: commonApiDoc.components,
+      },
     ])
   })
 })

--- a/app/utils/errors.js
+++ b/app/utils/errors.js
@@ -59,7 +59,7 @@ class NotAcceptableError extends HttpResponseError {
 const handleErrors = (err, req, res, next) => {
   if (err instanceof HttpResponseError) {
     logger.warn(`Error in ${req.path} message: ${err.message}`, req)
-    res.status(err.code).send(err.message)
+    res.status(err.code).send({ message: err.message })
   }
   // openapi validation
   else if (err.errors) {

--- a/app/utils/routeResponseValidator.js
+++ b/app/utils/routeResponseValidator.js
@@ -2,10 +2,37 @@ const OpenAPIResponseValidatorModule = require('openapi-response-validator')
 const commonApiDoc = require('../api-v1/api-doc')
 const logger = require('./Logger')
 
+const commonResponses = {
+  401: {
+    description: 'An unauthorized error occurred',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/UnauthorizedError',
+        },
+      },
+    },
+  },
+  default: {
+    description: 'An error occurred',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/Error',
+        },
+      },
+    },
+  },
+}
+
 const buildValidatedJsonHandler = (controller, apiDoc) => {
   const OpenAPIResponseValidator = OpenAPIResponseValidatorModule.default
+  const responses = {
+    ...commonResponses,
+    ...apiDoc.responses,
+  }
   const responseValidator = new OpenAPIResponseValidator({
-    responses: apiDoc.responses,
+    responses,
     components: commonApiDoc.components,
   })
   const handler = async function (req, res) {
@@ -18,10 +45,14 @@ const buildValidatedJsonHandler = (controller, apiDoc) => {
       res.status(status).json(response)
     }
   }
-  handler.apiDoc = apiDoc
+  handler.apiDoc = {
+    ...apiDoc,
+    responses,
+  }
   return handler
 }
 
 module.exports = {
+  commonResponses,
   buildValidatedJsonHandler,
 }

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.21.2'
+appVersion: '1.21.3'
 description: A Helm chart for inteli-api
-version: '1.21.2'
+version: '1.21.3'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -26,7 +26,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.21.2'
+  tag: 'v1.21.3'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.21.2",
+      "version": "1.21.3",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/test/integration/attachment.test.js
+++ b/test/integration/attachment.test.js
@@ -54,7 +54,7 @@ describe('attachments', function () {
   it('should return 400 - no file', async function () {
     const response = await postAttachmentNoFile(app, authToken)
     expect(response.status).to.equal(400)
-    expect(response.error.text).to.equal('Bad Request: No file uploaded')
+    expect(response.body).to.deep.equal({ message: 'Bad Request: No file uploaded' })
   })
 
   it('should return 201 - json object uploaded', async function () {

--- a/test/integration/auth.test.js
+++ b/test/integration/auth.test.js
@@ -4,8 +4,6 @@ const { expect } = require('chai')
 
 const { createHttpServer } = require('../../app/server')
 const { postAttachment } = require('../helper/routeHelper')
-const { getAuthToken } = require('../helper/auth')
-const { lastTokenId } = require('../../app/api-v1/services/dscpApiService')
 
 describe('authentication', function () {
   let app
@@ -22,12 +20,6 @@ describe('authentication', function () {
     const response = await postAttachment(app, Buffer.from('a'.repeat(size)), filename, authToken)
 
     expect(response.status).to.equal(401)
-    expect(response.error.text).to.have.equal('An error occurred during jwks verification')
-  })
-
-  it('should return 200 - valid token for dscp-api - test user', async function () {
-    const response = await lastTokenId(await getAuthToken())
-
-    expect(response).to.have.property('id')
+    expect(response.body).to.deep.equal({ message: 'An error occurred during jwks verification' })
   })
 })

--- a/test/integration/recipe.test.js
+++ b/test/integration/recipe.test.js
@@ -90,7 +90,7 @@ describe('Recipes', function () {
 
       const response = await postRecipeRoute(newRecipe, app, authToken)
       expect(response.status).to.equal(400)
-      expect(response.text).to.equal('Bad Request: Attachment id not found')
+      expect(response.body).to.deep.equal({ message: 'Bad Request: Attachment id not found' })
     })
 
     it('invalid supplier name errors', async function () {
@@ -107,7 +107,7 @@ describe('Recipes', function () {
 
       const response = await postRecipeRoute(newRecipe, app, authToken)
       expect(response.status).to.equal(400)
-      expect(response.text).to.equal('Bad Request: Member "invalid" does not exist')
+      expect(response.body).to.deep.equal({ message: 'Bad Request: Member "invalid" does not exist' })
     })
 
     it('identity server error propagates', async function () {
@@ -124,7 +124,7 @@ describe('Recipes', function () {
 
       const response = await postRecipeRoute(newRecipe, app, authToken)
       expect(response.status).to.equal(500)
-      expect(response.text).to.equal('Internal server error')
+      expect(response.body).to.deep.equal({ message: 'Internal server error' })
     })
   })
 


### PR DESCRIPTION
Adds validation to the remaining routes. This includes the following

* validation of `POST /attachment`
* validate `POST /order`
* validate `GET /recipe/{id}`
* validate `POST /recipe/{id}/creation`
* validate `GET /recipe/{id}/creation/{creationId}`
* moving default responses to a `commonResponses` definition. This meant I could implement `UnauthorisedError` in one place rather than everywhere. Note this is what has made the diff large
* remove `should return 200 - valid token for dscp-api - test user` auth test. This test never actually hits the service