### PR TITLE
Bug/run process routes

### DIFF
--- a/app/api-v1/controllers/Order/__tests__/__fixtures__/recipes.json
+++ b/app/api-v1/controllers/Order/__tests__/__fixtures__/recipes.json
@@ -2,16 +2,16 @@
   {
     "id": "50000000-0000-1000-5500-000000000001",
     "supplier": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    "token_id": 20
+    "latest_token_id": 20
   },
   {
     "id": "50000000-0000-1000-5600-000000000001",
     "supplier": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    "token_id": null
+    "latest_token_id": null
   },
   {
     "id": "50000000-0000-1000-5700-000000000001",
     "supplier": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-    "token_id": 2
+    "latest_token_id": 2
   }
 ]

--- a/app/api-v1/controllers/Order/__tests__/helpers.test.js
+++ b/app/api-v1/controllers/Order/__tests__/helpers.test.js
@@ -9,7 +9,7 @@ const { NoTokenError, NothingToProcess } = require('../../../../utils/errors')
 const payload = {
   items: recipesExample.map((el) => el.id),
   status: 'Submitted',
-  requiredBy: '2022-06-13T11:20:35.466Z',
+  required_by: '2022-06-13T11:20:35.466Z',
   selfAddress: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
   supplier: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
   transaction: {

--- a/app/api-v1/controllers/Order/__tests__/orders.test.js
+++ b/app/api-v1/controllers/Order/__tests__/orders.test.js
@@ -12,15 +12,15 @@ const dscpApiUrl = `http://${DSCP_API_HOST}:${DSCP_API_PORT}`
 const recipeExamples = [
   {
     id: '50000000-0000-1000-5500-000000000001',
-    token_id: 20,
+    latest_token_id: 20,
   },
   {
     id: '50000000-0000-1000-5600-000000000001',
-    token_id: null,
+    latest_token_id: null,
   },
   {
     id: '50000000-0000-1000-5700-000000000001',
-    token_id: 2,
+    latest_token_id: 2,
   },
 ]
 const createTransaction = async (req) => {

--- a/app/api-v1/controllers/Order/__tests__/orders.test.js
+++ b/app/api-v1/controllers/Order/__tests__/orders.test.js
@@ -207,7 +207,7 @@ describe('Order controller', () => {
           stubs.insertTransaction.resolves({
             id: '50000000-0000-1000-3000-000000000001',
             status: 'Submitted',
-            createdAt: '2022-06-11T08:47:23.397Z',
+            created_at: '2022-06-11T08:47:23.397Z',
           })
           stubs.getOrder.resolves([
             {
@@ -233,7 +233,6 @@ describe('Order controller', () => {
 
         it('calls run process with formatted body', () => {
           expect(runProcessReq.isDone()).to.equal(true)
-          expect(runProcessBody).to.be.undefined
         })
 
         it('call database method to insert a new entry in order_transactions', () => {
@@ -241,11 +240,12 @@ describe('Order controller', () => {
         })
 
         it('returns 201 along with other details as per api-doc', () => {
-          expect(response.status).to.equal(201)
-          expect(response.transaction).to.deep.equal({
+          const { status, response: body } = response
+          expect(status).to.equal(201)
+          expect(body).to.deep.equal({
             id: '50000000-0000-1000-3000-000000000001',
             status: 'Submitted',
-            createdAt: '2022-06-11T08:47:23.397Z',
+            submittedAt: '2022-06-11T08:47:23.397Z',
           })
         })
       })

--- a/app/api-v1/controllers/Order/helpers.js
+++ b/app/api-v1/controllers/Order/helpers.js
@@ -32,7 +32,7 @@ const buildOrderOutput = (data, recipes) => ({
 exports.mapOrderData = async (data) => {
   if (!data.items || data.items.length < 1) throw new NothingToProcess()
   const records = await db.getRecipeByIDs(data.items)
-  const tokenIds = records.map((el) => el.token_id)
+  const tokenIds = records.map((el) => el.latest_token_id)
   if (!tokenIds.every(Boolean)) throw new NoTokenError('recipes')
 
   const recipes = tokenIds.reduce((output, id) => {

--- a/app/api-v1/controllers/Order/helpers.js
+++ b/app/api-v1/controllers/Order/helpers.js
@@ -2,15 +2,16 @@ const db = require('../../../db')
 const { NoTokenError, NothingToProcess } = require('../../../utils/errors')
 
 /*eslint-disable */
-const buildRecipeOutputs = (data, recipes) => recipes.map((_, i) => ({
-  roles: {
-    Owner: data.selfAddress,
-    Buyer: data.selfAddress,
-    Supplier: data.supplier,
-  },
-  metadata: { type: { type: 'LITERAL', value: 'RECIPE' } },
-  parent_index: i,
-}))
+const buildRecipeOutputs = (data, recipes) =>
+  recipes.map((_, i) => ({
+    roles: {
+      Owner: data.selfAddress,
+      Buyer: data.selfAddress,
+      Supplier: data.supplier,
+    },
+    metadata: { type: { type: 'LITERAL', value: 'RECIPE' } },
+    parent_index: i,
+  }))
 
 const buildOrderOutput = (data, recipes) => ({
   roles: {
@@ -21,10 +22,10 @@ const buildOrderOutput = (data, recipes) => ({
   metadata: {
     type: { type: 'LITERAL', value: 'ORDER' },
     status: { type: 'LITERAL', value: data.status },
-    requiredBy: { type: 'LITERAL', value: data.requiredBy },
+    requiredBy: { type: 'LITERAL', value: data.required_by },
     transactionId: { type: 'LITERAL', value: data.transaction.id.replace(/[-]/g, '') },
     ...recipes,
-    },
+  },
 })
 /*eslint-enable */
 

--- a/app/api-v1/controllers/Order/index.js
+++ b/app/api-v1/controllers/Order/index.js
@@ -1,7 +1,7 @@
 const { runProcess } = require('../../../utils/dscp-api')
 const db = require('../../../db')
 const { mapOrderData } = require('./helpers')
-const idenity = require('../../services/identityService')
+const identity = require('../../services/identityService')
 const { BadRequestError, NotFoundError, IdentityError } = require('../../../utils/errors')
 
 module.exports = {
@@ -25,7 +25,7 @@ module.exports = {
       const [order] = await db.getOrder(id)
       if (!order) throw new NotFoundError('order')
 
-      const selfAddress = await idenity.getMemberBySelf()
+      const selfAddress = await identity.getMemberBySelf({ token: {} })
       if (!selfAddress) throw new IdentityError()
 
       const transaction = await db.insertOrderTransaction(id)
@@ -35,7 +35,11 @@ module.exports = {
 
       return {
         status: 201,
-        transaction,
+        response: {
+          id: transaction.id,
+          submittedAt: new Date(transaction.created_at).toISOString(),
+          status: transaction.status,
+        },
       }
     },
   },

--- a/app/api-v1/controllers/Order/index.js
+++ b/app/api-v1/controllers/Order/index.js
@@ -25,7 +25,7 @@ module.exports = {
       const [order] = await db.getOrder(id)
       if (!order) throw new NotFoundError('order')
 
-      const selfAddress = await identity.getMemberBySelf({ token: {} })
+      const selfAddress = await identity.getMemberBySelf(req)
       if (!selfAddress) throw new IdentityError()
 
       const transaction = await db.insertOrderTransaction(id)

--- a/app/api-v1/controllers/Recipe/__tests__/transactions.test.js
+++ b/app/api-v1/controllers/Recipe/__tests__/transactions.test.js
@@ -195,7 +195,7 @@ describe('recipe controller', () => {
         expect(dataHeader).to.equal('Content-Disposition: form-data; name="request"\r')
         expect(inputs).to.deep.equal([])
         expect(roles).to.deep.contain({
-          Owner: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+          Owner: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
         })
         expect(metadata).to.deep.contain({
           externalId: { type: 'LITERAL', value: 'TEST-externalId' },
@@ -238,7 +238,7 @@ describe('recipe controller', () => {
         expect(stubs.insertTransaction.getCall(0).args).to.be.deep.equal(['recipe-id'])
       })
 
-      it.only('returns 200 along with the transaction id', () => {
+      it('returns 200 along with the transaction id', () => {
         const { status, response: body } = response
         expect(status).to.be.equal(200)
         expect(body).to.deep.equal({

--- a/app/api-v1/controllers/Recipe/__tests__/transactions.test.js
+++ b/app/api-v1/controllers/Recipe/__tests__/transactions.test.js
@@ -116,7 +116,11 @@ describe('recipe controller', () => {
   describe('transactions /create', () => {
     beforeEach(async () => {
       stubs.getRecipe = stub(db, 'getRecipe').resolves([])
-      stubs.insertTransaction = stub(db, 'insertRecipeTransaction').resolves({ id: 'transaction-uuid' })
+      stubs.insertTransaction = stub(db, 'insertRecipeTransaction').resolves({
+        id: '50000000-0000-1000-3000-000000000001',
+        status: 'Submitted',
+        created_at: '2022-06-11T08:47:23.397Z',
+      })
     })
     afterEach(() => {
       stubs.insertTransaction.restore()
@@ -165,7 +169,11 @@ describe('recipe controller', () => {
         stubs.getRecipe.restore()
         stubs.insertTransaction.restore()
         stubs.getRecipe = stub(db, 'getRecipe').resolves([recipeExample])
-        stubs.insertTransaction = stub(db, 'insertRecipeTransaction').resolves({ id: 'transaction-uuid' })
+        stubs.insertTransaction = stub(db, 'insertRecipeTransaction').resolves({
+          id: '50000000-0000-1000-3000-000000000001',
+          status: 'Submitted',
+          created_at: '2022-06-11T08:47:23.397Z',
+        })
         response = await submitTransaction(postPayload)
       })
 
@@ -197,7 +205,7 @@ describe('recipe controller', () => {
           requiredCerts: { type: 'FILE', value: 'required_certs.json' },
           type: { type: 'LITERAL', value: 'RECIPE' },
           image: { type: 'FILE', value: 'foo.jpg' },
-          transactionId: { type: 'LITERAL', value: 'transaction-uuid' },
+          transactionId: { type: 'LITERAL', value: '50000000000010003000000000000001' },
         })
       })
 
@@ -230,11 +238,13 @@ describe('recipe controller', () => {
         expect(stubs.insertTransaction.getCall(0).args).to.be.deep.equal(['recipe-id'])
       })
 
-      it('returns 200 along with the transaction id', () => {
-        expect(response).to.deep.equal({
-          status: 200,
-          message: 'transaction transaction-uuid has been created',
-          transactionId: 'transaction-uuid',
+      it.only('returns 200 along with the transaction id', () => {
+        const { status, response: body } = response
+        expect(status).to.be.equal(200)
+        expect(body).to.deep.equal({
+          id: '50000000-0000-1000-3000-000000000001',
+          status: 'Submitted',
+          submittedAt: '2022-06-11T08:47:23.397Z',
         })
       })
     })

--- a/app/api-v1/controllers/Recipe/helpers.js
+++ b/app/api-v1/controllers/Recipe/helpers.js
@@ -4,7 +4,7 @@ exports.mapRecipeData = (data) => ({
   material: { type: 'LITERAL', value: data.material },
   alloy: { type: 'LITERAL', value: data.alloy },
   requiredCerts: { type: 'FILE', value: 'required_certs.json' },
-  transactionId: { type: 'LITERAL', value: data.transaction.id },
+  transactionId: { type: 'LITERAL', value: data.transaction.id.replace(/[-]/g, '') },
   type: { type: 'LITERAL', value: 'RECIPE' },
   image: { type: 'FILE', value: data.filename },
 })

--- a/app/db/index.js
+++ b/app/db/index.js
@@ -77,14 +77,14 @@ async function insertRecipeTransaction(id) {
       status: 'Submitted',
       type: 'Creation',
     })
-    .returning(['id'])
+    .returning(['id', 'status', 'created_at'])
     .then((t) => t[0])
 }
 
 async function insertOrderTransaction(id) {
   return client('order_transactions')
     .insert({
-      id,
+      order_id: id,
       status: 'Submitted',
       type: 'Submission',
     })

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
       - API_HOST=dscp-node
       - API_PORT=9944
       - USER_URI=//Alice
-      - IPFS_HOST=dscp-ipfs
+      - IPFS_HOST=ipfs
       - IPFS_PORT=5001
       - LOG_LEVEL=trace
       - AUTH_JWKS_URI=https://inteli.eu.auth0.com/.well-known/jwks.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - DB_NAME=dscp
       - DB_USERNAME=postgres
       - DB_PASSWORD=postgres
-      - SELF_ADDRESS=5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
+      - SELF_ADDRESS=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
       - AUTH_TYPE=${AUTH_TYPE:-NONE}
 
   dscp-node:

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.24.3'
+appVersion: '1.24.4'
 description: A Helm chart for inteli-api
-version: '1.24.3'
+version: '1.24.4'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -27,7 +27,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.24.3'
+  tag: 'v1.24.4'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/migrations/20220614123448_add_recipe_and_order_token_id.js
+++ b/migrations/20220614123448_add_recipe_and_order_token_id.js
@@ -4,11 +4,13 @@
  */
 exports.up = async (knex) => {
   await knex.schema.alterTable('recipes', (def) => {
-    def.integer('token_id')
+    def.integer('latest_token_id')
+    def.integer('original_token_id')
   })
 
   await knex.schema.alterTable('orders', (def) => {
-    def.integer('token_id')
+    def.integer('latest_token_id')
+    def.integer('original_token_id')
   })
 }
 
@@ -18,10 +20,12 @@ exports.up = async (knex) => {
  */
 exports.down = async (knex) => {
   await knex.schema.alterTable('recipes', (def) => {
-    def.dropColumn('token_id')
+    def.dropColumn('latest_token_id')
+    def.dropColumn('original_token_id')
   })
 
   await knex.schema.alterTable('orders', (def) => {
-    def.dropColumn('token_id')
+    def.dropColumn('latest_token_id')
+    def.dropColumn('original_token_id')
   })
 }

--- a/migrations/20220614123448_add_recipe_and_order_token_id.js
+++ b/migrations/20220614123448_add_recipe_and_order_token_id.js
@@ -1,0 +1,27 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.alterTable('recipes', (def) => {
+    def.integer('token_id')
+  })
+
+  await knex.schema.alterTable('orders', (def) => {
+    def.integer('token_id')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.alterTable('recipes', (def) => {
+    def.dropColumn('token_id')
+  })
+
+  await knex.schema.alterTable('orders', (def) => {
+    def.dropColumn('token_id')
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.24.3",
+      "version": "1.24.4",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes the following bugs:
- [x] OpenAPI response validation errors
- [x] `dscp-api` runs as Alice but `dscp-identity-service` was using Bob's address for `self` 
- [x] `dscp-api` had the incorrect host name for `ipfs` in docker  
- [x] adds `latest_token_id` + `original_token_id` columns to `recipes` and `orders`. Expect them to be populated by a future blockchain watcher (I manually updated when testing). `latest_token_id` is used for burning.
- [x] some camel case/snake case mix-ups when returning from `db` 
- [x] transaction id was over max metadata value length when adding recipe to chain

Also updates `recipe` `roles` based on recent token format documentation