### PR TITLE
Rename Purchaser to Buyer

### DIFF
--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -117,7 +117,7 @@ const apiDoc = {
               'Name of the OEM who owns the design of the recipe. This information is not stored directly on-chain',
             type: 'string',
             maxLength: 255,
-            example: 'PurchaserAlias',
+            example: 'BuyerAlias',
           },
         },
       },
@@ -322,12 +322,12 @@ const apiDoc = {
             description: 'local id of the purchase-order',
             allOf: [{ $ref: '#/components/schemas/ObjectReference' }],
           },
-          purchaser: {
+          buyer: {
             description:
               'Name of the submitter of the purchase-order. This information is not stored directly on-chain',
             type: 'string',
             maxLength: 255,
-            example: 'PurchaserAlias',
+            example: 'BuyerAlias',
           },
           status: {
             type: 'string',

--- a/app/api-v1/controllers/Order/__tests__/orders.test.js
+++ b/app/api-v1/controllers/Order/__tests__/orders.test.js
@@ -274,7 +274,6 @@ describe('order controller', () => {
             '50000000-0000-1000-5700-000000000001',
           ],
           status: 'Created',
-          buyer: 'self-alias',
           buyerAddress: 'self-address',
         })
       })

--- a/app/api-v1/controllers/Order/__tests__/orders.test.js
+++ b/app/api-v1/controllers/Order/__tests__/orders.test.js
@@ -274,9 +274,9 @@ describe('order controller', () => {
             '50000000-0000-1000-5600-000000000001',
             '50000000-0000-1000-5700-000000000001',
           ],
-          purchaserAddress: 'self-address',
+          buyerAddress: 'self-address',
           status: 'Created',
-          purchaser: 'self-address',
+          buyer: 'self-address',
         })
       })
 

--- a/app/api-v1/controllers/Order/__tests__/orders.test.js
+++ b/app/api-v1/controllers/Order/__tests__/orders.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai')
 const { stub } = require('sinon')
 const orderController = require('../index')
 const db = require('../../../../db')
-const identifyService = require('../../../services/identityService')
+const identityService = require('../../../services/identityService')
 const { BadRequestError, NotFoundError, IdentityError, NoTokenError } = require('../../../../utils/errors')
 const { DSCP_API_HOST, DSCP_API_PORT } = require('../../../../env')
 
@@ -64,12 +64,9 @@ describe('order controller', () => {
   describe('/order - post endpoint for creating order in local db', () => {
     beforeEach(async () => {
       stubs.getRecipeIds = stub(db, 'getRecipeByIDs').resolves(recipeExamples)
-      stubs.identityByAlias = stub(identifyService, 'getMemberByAlias')
-        .onFirstCall()
-        .resolves({ address: 'supplier-address' })
-        .onSecondCall()
-        .resolves({ alias: 'self-address' })
-      stubs.identitySelf = stub(identifyService, 'getMemberBySelf').resolves('self-address')
+      stubs.identityByAlias = stub(identityService, 'getMemberByAlias').resolves({ address: 'supplier-address' })
+      stubs.identityByAddress = stub(identityService, 'getMemberByAddress').resolves({ alias: 'self-alias' })
+      stubs.identitySelf = stub(identityService, 'getMemberBySelf').resolves('self-address')
       stubs.insertOrder = stub(db, 'postOrderDb').resolves([
         {
           id: 'order-id',
@@ -81,6 +78,7 @@ describe('order controller', () => {
     afterEach(() => {
       stubs.getRecipeIds.restore()
       stubs.identityByAlias.restore()
+      stubs.identityByAddress.restore()
       stubs.identitySelf.restore()
       stubs.insertOrder.restore()
     })
@@ -112,7 +110,7 @@ describe('order controller', () => {
         stubs.identityByAlias.rejects('some error - identity alias')
         response = await postOrder({
           body: {
-            supplier: 'supplier-address-req',
+            supplier: 'supplier-alias',
             description: 'some description - test',
             requiredBy: '2022-06-17T07:31:37.602Z',
             items: recipeExamples.map((el) => el.id),
@@ -132,7 +130,7 @@ describe('order controller', () => {
           stubs.getRecipeIds.resolves([])
           response = await postOrder({
             body: {
-              supplier: 'supplier-address-req',
+              supplier: 'supplier-alias',
               description: 'some description - test',
               requiredBy: '2022-06-17T07:31:37.602Z',
               items: recipeExamples.map((el) => el.id),
@@ -161,7 +159,7 @@ describe('order controller', () => {
 
           response = await postOrder({
             body: {
-              supplier: 'supplier-address-req-mismatch',
+              supplier: 'supplier-alias-mismatch',
               description: 'some description - test',
               requiredBy: '2022-06-17T07:31:37.602Z',
               items: recipeExamples.map((el) => el.id),
@@ -191,7 +189,7 @@ describe('order controller', () => {
 
         response = await postOrder({
           body: {
-            supplier: 'supplier-address-req',
+            supplier: 'supplier-alias',
             description: 'some description - test',
             requiredBy: '2022-06-17T07:31:37.602Z',
             items: recipeExamples.map((el) => el.id),
@@ -210,7 +208,7 @@ describe('order controller', () => {
 
         response = await postOrder({
           body: {
-            supplier: 'supplier-address-req-mismatch',
+            supplier: 'supplier-alias',
             description: 'some description - test',
             requiredBy: '2022-06-17T07:31:37.602Z',
             items: recipeExamples.map((el) => el.id),
@@ -225,7 +223,7 @@ describe('order controller', () => {
       it('gets aliases from identity service', () => {
         expect(stubs.identityByAlias.getCall(0).args[0]).to.deep.equal({
           body: {
-            supplier: 'supplier-address-req-mismatch',
+            supplier: 'supplier-alias',
             description: 'some description - test',
             requiredBy: '2022-06-17T07:31:37.602Z',
             items: [
@@ -235,9 +233,9 @@ describe('order controller', () => {
             ],
           },
         })
-        expect(stubs.identityByAlias.getCall(1).args[0]).to.deep.equal({
+        expect(stubs.identityByAddress.getCall(0).args[0]).to.deep.equal({
           body: {
-            supplier: 'supplier-address-req-mismatch',
+            supplier: 'supplier-alias',
             description: 'some description - test',
             requiredBy: '2022-06-17T07:31:37.602Z',
             items: [
@@ -252,7 +250,7 @@ describe('order controller', () => {
       it('retrieves self address', () => {
         expect(stubs.identitySelf.getCall(0).args[0]).to.deep.equal({
           body: {
-            supplier: 'supplier-address-req-mismatch',
+            supplier: 'supplier-alias',
             description: 'some description - test',
             requiredBy: '2022-06-17T07:31:37.602Z',
             items: [
@@ -266,7 +264,8 @@ describe('order controller', () => {
 
       it('validates properties by calling a helper method [validate]', () => {
         expect(stubs.insertOrder.getCall(0).args[0]).to.deep.equal({
-          supplier: 'supplier-address',
+          supplier: 'supplier-alias',
+          supplierAddress: 'supplier-address',
           description: 'some description - test',
           requiredBy: '2022-06-17T07:31:37.602Z',
           items: [
@@ -274,9 +273,9 @@ describe('order controller', () => {
             '50000000-0000-1000-5600-000000000001',
             '50000000-0000-1000-5700-000000000001',
           ],
-          buyerAddress: 'self-address',
           status: 'Created',
-          buyer: 'self-address',
+          buyer: 'self-alias',
+          buyerAddress: 'self-address',
         })
       })
 
@@ -284,9 +283,10 @@ describe('order controller', () => {
         expect(response.status).to.equal(201)
         expect(response.response).to.deep.equal({
           id: 'order-id',
-          supplier: 'supplier-address-req-mismatch',
+          supplier: 'supplier-alias',
           description: 'some description - test',
           requiredBy: '2022-06-17T07:31:37.602Z',
+          buyer: 'self-alias',
           items: [
             '50000000-0000-1000-5500-000000000001',
             '50000000-0000-1000-5600-000000000001',
@@ -331,7 +331,7 @@ describe('order controller', () => {
         stubs.insertTransaction = stub(db, 'insertOrderTransaction').resolves([])
         stubs.getRecipeIds = stub(db, 'getRecipeByIDs').resolves(recipeExamples)
         stubs.getOrder = stub(db, 'getOrder').resolves([])
-        stubs.getSelf = stub(identifyService, 'getMemberBySelf').resolves(null)
+        stubs.getSelf = stub(identityService, 'getMemberBySelf').resolves(null)
       })
       afterEach(() => {
         stubs.getSelf.restore()

--- a/app/api-v1/controllers/Order/helpers.js
+++ b/app/api-v1/controllers/Order/helpers.js
@@ -11,7 +11,7 @@ exports.validate = async (body) => {
     throw new BadRequestError('recipe not found')
   } else {
     recipes.map((recipeItem) => {
-      if (recipeItem.supplier != body.supplier) {
+      if (recipeItem.supplier != body.supplierAddress) {
         throw new BadRequestError('invalid supplier')
       }
     })

--- a/app/api-v1/controllers/Order/index.js
+++ b/app/api-v1/controllers/Order/index.js
@@ -19,9 +19,9 @@ module.exports = {
     const validated = await validate({
       ...req.body,
       supplier: supplierAddress,
-      purchaserAddress: selfAlias,
+      buyerAddress: selfAlias,
       status: 'Created',
-      purchaser: selfAddress,
+      buyer: selfAddress,
     })
     const [result] = await db.postOrderDb(validated)
 

--- a/app/api-v1/controllers/Order/index.js
+++ b/app/api-v1/controllers/Order/index.js
@@ -20,7 +20,6 @@ module.exports = {
       ...req.body,
       supplierAddress: supplierAddress,
       status: 'Created',
-      buyer: selfAlias,
       buyerAddress: selfAddress,
     })
     const [result] = await db.postOrderDb(validated)

--- a/app/api-v1/controllers/Order/index.js
+++ b/app/api-v1/controllers/Order/index.js
@@ -14,14 +14,14 @@ module.exports = {
 
     const { address: supplierAddress } = await identity.getMemberByAlias(req, req.body.supplier)
     const selfAddress = await identity.getMemberBySelf(req)
-    const { alias: selfAlias } = await identity.getMemberByAlias(req, selfAddress)
+    const { alias: selfAlias } = await identity.getMemberByAddress(req, selfAddress)
 
     const validated = await validate({
       ...req.body,
-      supplier: supplierAddress,
-      buyerAddress: selfAlias,
+      supplierAddress: supplierAddress,
       status: 'Created',
-      buyer: selfAddress,
+      buyer: selfAlias,
+      buyerAddress: selfAddress,
     })
     const [result] = await db.postOrderDb(validated)
 
@@ -29,6 +29,7 @@ module.exports = {
       status: 201,
       response: {
         ...result,
+        buyer: selfAlias,
         ...req.body,
       },
     }

--- a/app/db/index.js
+++ b/app/db/index.js
@@ -18,13 +18,13 @@ const client = knex({
 async function postOrderDb(reqBody) {
   return client('orders')
     .insert({
-      supplier: reqBody.supplier,
+      supplier: reqBody.supplierAddress,
       required_by: reqBody.requiredBy,
       items: reqBody.items,
       buyer: reqBody.buyerAddress,
       status: reqBody.status,
     })
-    .returning('*')
+    .returning(['id', 'status'])
 }
 
 async function getAttachment(id) {

--- a/app/db/index.js
+++ b/app/db/index.js
@@ -21,7 +21,7 @@ async function postOrderDb(reqBody) {
       supplier: reqBody.supplier,
       required_by: reqBody.requiredBy,
       items: reqBody.items,
-      purchaser: reqBody.purchaserAddress,
+      buyer: reqBody.buyerAddress,
       status: reqBody.status,
     })
     .returning('*')

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.27.0'
+appVersion: '1.27.1'
 description: A Helm chart for inteli-api
-version: '1.27.0'
+version: '1.27.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -27,7 +27,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.27.0'
+  tag: 'v1.27.1'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/migrations/20220626162554_rename_order_purchaser_to_buyer.js
+++ b/migrations/20220626162554_rename_order_purchaser_to_buyer.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.alterTable('orders', (def) => {
+    def.renameColumn('purchaser', 'buyer')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.alterTable('orders', (def) => {
+    def.renameColumn('buyer', 'purchaser')
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.27.0",
+      "version": "1.27.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/test/integration/order.test.js
+++ b/test/integration/order.test.js
@@ -56,7 +56,7 @@ describeAuthOnly('order - authenticated', function () {
       }
       const response = await postOrderRoute(newOrder, app, authToken)
       expect(response.body.supplier).to.equal('valid-1')
-      expect(response.body.purchaser).to.equal('valid-2')
+      expect(response.body.buyer).to.equal('valid-2')
       expect(response.body.items).to.contain('10000000-0000-1000-8000-000000000000')
       expect(response.status).to.equal(201)
     })
@@ -159,7 +159,7 @@ describeNoAuthOnly('order - no auth', function () {
       }
       const response = await postOrderRoute(newOrder, app, null)
       expect(response.body.supplier).to.equal('valid-1')
-      expect(response.body.purchaser).to.equal('valid-2')
+      expect(response.body.buyer).to.equal('valid-2')
       expect(response.body.items).to.contain('10000000-0000-1000-8000-000000000000')
       expect(response.status).to.equal(201)
     })

--- a/test/seeds/orders.js
+++ b/test/seeds/orders.js
@@ -64,15 +64,20 @@ const seed = async () => {
   ])
 
   /* eslint-disable */
-  await Promise.all(['Created', 'Submitted', 'Rejected', 'Accepted', 'Amended'].map((status, i) => client('orders').insert([{
-      id: `36345f4f-6535-42e2-83f9-79e2e195e11${i}`,
-      supplier: '36345f4f-0000-42e2-83f9-79e2e195e000',
-      items: ['10000000-0000-1000-9000-000000000000'],
-      purchaser: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
-      status,
-      required_by: '2022-10-21T10:10:10.919Z',
-    },
-  ])))
+  await Promise.all(
+    ['Created', 'Submitted', 'Rejected', 'Accepted', 'Amended'].map((status, i) =>
+      client('orders').insert([
+        {
+          id: `36345f4f-6535-42e2-83f9-79e2e195e11${i}`,
+          supplier: '36345f4f-0000-42e2-83f9-79e2e195e000',
+          items: ['10000000-0000-1000-9000-000000000000'],
+          buyer: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
+          status,
+          required_by: '2022-10-21T10:10:10.919Z',
+        },
+      ])
+    )
+  )
   /* eslint-enable */
 
   // with recipe that does not have a token_id
@@ -81,7 +86,7 @@ const seed = async () => {
       id: '36345f4f-6535-42e2-83f9-79e2e195e101',
       supplier: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
       items: ['10000000-0000-1000-9000-000000000000'],
-      purchaser: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
+      buyer: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',
       status: 'Created',
       required_by: '2022-10-21T11:45:46.919Z',
     },

--- a/test/seeds/orders.js
+++ b/test/seeds/orders.js
@@ -63,7 +63,6 @@ const seed = async () => {
     },
   ])
 
-  /* eslint-disable */
   await Promise.all(
     ['Created', 'Submitted', 'Rejected', 'Accepted', 'Amended'].map((status, i) =>
       client('orders').insert([
@@ -78,7 +77,6 @@ const seed = async () => {
       ])
     )
   )
-  /* eslint-enable */
 
   // with recipe that does not have a token_id
   await client('orders').insert([


### PR DESCRIPTION
- [x] Rename `Purchaser` on `Orders` to `Buyer` to be consistent with the `Buyer` role in the `dscp-node` `Role` enum.
- [x] Fix a bug where `selfAlias` was stored for `buyer` in `orders` table rather than `selfAddress`. 
- [x] Fix some `address/alias` confusion.
- [x] Make `POST /order` response match the spec (was returning every column from `orders` table).