### PR TITLE
Bug/GET attachments

### DIFF
--- a/app/api-v1/controllers/Attachment/__tests__/attachments.test.js
+++ b/app/api-v1/controllers/Attachment/__tests__/attachments.test.js
@@ -91,10 +91,6 @@ describe('Attachment controller', () => {
       })
     })
 
-    afterEach(() => {
-      stubs.getAttachment.restore()
-    })
-
     describe('happy path - json attachment', () => {
       beforeEach(async () => {
         stubs.getAttachment.resolves([jsonAttachment])
@@ -117,53 +113,41 @@ describe('Attachment controller', () => {
   })
 
   describe('/attachment/ - get all endpoint', () => {
-    beforeEach(() => {
-      stubs.getAttachments.restore()
-      stubs.getAttachments = stub(db, 'getAttachments').resolves([])
-    })
-    afterEach(() => {
-      stubs.getAttachments.restore()
-    })
     describe('if no attachments are found', () => {
       beforeEach(async () => {
-        stubs.getAttachments.restore()
-        stubs.getAttachments = stub(db, 'getAttachments').resolves([])
+        stubs.getAttachments.resolves([])
         response = await getAttachments()
       })
-      it('performs a database call too check for attachments', () => {
+      it('performs a database call to check for attachments', () => {
         expect(stubs.getAttachments.calledOnce).to.equal(true)
       })
 
-      it('throws an error', async () => {
-        expect(response).to.be.an.instanceOf(NotFoundError)
-        expect(response.message).to.be.equal('Not Found: Attachments Not Found')
+      it('returns empty list', async () => {
+        expect(response.response).to.deep.equal([])
       })
     })
 
     describe('attachments are found', () => {
       beforeEach(async () => {
-        stubs.getAttachments.restore()
-        stubs.getAttachments = stub(db, 'getAttachments').resolves([allAttachments])
+        stubs.getAttachments.resolves(allAttachments)
         response = await getAttachments()
       })
-      afterEach(() => {
-        stubs.getAttachments.restore()
-      })
+
       it('returns a 200 status', async () => {
         expect(response.status).to.be.equal(200)
       })
 
-      it('resturns a list of attachments', async () => {
+      it('returns a list of attachments', async () => {
         expect(response.response).to.deep.equal([
           {
             id: '00000000-0000-1000-8000-000000000001',
             filename: 'foo1.jpg',
-            size: '7',
+            size: 7,
           },
           {
             id: '00000000-0000-1000-9000-000000000001',
             filename: 'json',
-            size: '35',
+            size: 29,
           },
         ])
       })

--- a/app/api-v1/controllers/Attachment/__tests__/attachments_fixtures.js
+++ b/app/api-v1/controllers/Attachment/__tests__/attachments_fixtures.js
@@ -2,7 +2,7 @@ module.exports = {
   fileAttachment: {
     id: '00000000-0000-1000-8000-000000000001',
     filename: 'foo1.jpg',
-    binary_blob: 9999999,
+    binary_blob: '9999999',
   },
   jsonAttachment: {
     id: '00000000-0000-1000-9000-000000000001',
@@ -13,7 +13,7 @@ module.exports = {
     {
       id: '00000000-0000-1000-8000-000000000001',
       filename: 'foo1.jpg',
-      binary_blob: 9999999,
+      binary_blob: '9999999',
     },
     {
       id: '00000000-0000-1000-9000-000000000001',

--- a/app/api-v1/controllers/Attachment/index.js
+++ b/app/api-v1/controllers/Attachment/index.js
@@ -18,19 +18,14 @@ const returnOctet = ({ filename, binary_blob }) => ({
   response: binary_blob,
 })
 
-const getSize = (blob) => {
-  return Buffer.from(JSON.stringify(blob)).length.toString()
-}
-
 module.exports = {
   get: async function () {
-    const [result] = await db.getAttachments()
-    if (!result) throw new NotFoundError('Attachments Not Found')
-    const res = result.map((item) => {
+    const attachments = await db.getAttachments()
+    const res = attachments.map((item) => {
       return {
         id: item.id,
         filename: item.filename,
-        size: getSize(item.binary_blob),
+        size: item.binary_blob.length,
       }
     })
     return {

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.27.0'
+appVersion: '1.27.2'
 description: A Helm chart for inteli-api
-version: '1.27.0'
+version: '1.27.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -27,7 +27,7 @@ ingress:
 image:
   repository: ghcr.io/digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.27.0'
+  tag: 'v1.27.2'
   pullSecrets: ['ghcr-digicatapult']
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.27.0",
+  "version": "1.27.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.27.0",
+      "version": "1.27.2",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.27.0",
+  "version": "1.27.2",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {

--- a/test/helper/routeHelper.js
+++ b/test/helper/routeHelper.js
@@ -152,7 +152,7 @@ async function getAttachmentRouteJSON(id, { app }, token) {
       return response
     })
     .catch((err) => {
-      console.error(`postAttachmentErr ${err}`)
+      console.error(`getAttachmentRouteJSONErr ${err}`)
       return err
     })
 }
@@ -167,7 +167,21 @@ async function getAttachmentRouteOctet(id, { app }, token) {
       return response
     })
     .catch((err) => {
-      console.error(`postAttachmentErr ${err}`)
+      console.error(`getAttachmentRouteOctetErr ${err}`)
+      return err
+    })
+}
+
+async function getAttachments({ app }, token) {
+  return request(app)
+    .get(`/${API_MAJOR_VERSION}/attachment`)
+    .set('Authorization', `Bearer ${token}`)
+    .send()
+    .then((response) => {
+      return response
+    })
+    .catch((err) => {
+      console.error(`getAttachmentsErr ${err}`)
       return err
     })
 }
@@ -199,4 +213,5 @@ module.exports = {
   postAttachmentJSON,
   getAttachmentRouteJSON,
   getAttachmentRouteOctet,
+  getAttachments,
 }

--- a/test/integration/attachment.test.js
+++ b/test/integration/attachment.test.js
@@ -11,6 +11,7 @@ const {
   postAttachmentJSON,
   getAttachmentRouteJSON,
   getAttachmentRouteOctet,
+  getAttachments,
 } = require('../helper/routeHelper')
 
 const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
@@ -158,7 +159,12 @@ describeNoAuthOnly('attachments - no auth', function () {
   let app
 
   before(async function () {
+    await cleanup()
     app = await createHttpServer()
+  })
+
+  afterEach(async function () {
+    await cleanup()
   })
 
   it('should return 201 - file uploaded', async function () {
@@ -170,5 +176,19 @@ describeNoAuthOnly('attachments - no auth', function () {
     expect(response.body).to.have.property('id')
     expect(response.body.filename).to.equal(filename)
     expect(response.body.size).to.equal(size)
+  })
+
+  it('should return 200 - list attachments', async function () {
+    const size = 100
+    const filename = 'test.pdf'
+    await postAttachment(app, Buffer.from('a'.repeat(size)), filename, null)
+
+    const response = await getAttachments(app, null)
+
+    expect(response.status).to.equal(200)
+    expect(response.body).to.have.length(1)
+    expect(response.body[0]).to.have.property('id')
+    expect(response.body[0].filename).to.equal(filename)
+    expect(response.body[0].size).to.equal(size)
   })
 })


### PR DESCRIPTION
- [x] make `GET /attachment` return `200: []` instead of a `404`.
- [x] fix bug where the route was returning `500` if >0 attachments in the db.
- [x] make `size` in each attachment of the response an `int` rather than `string`.
- [x] Add an integration test for `GET /attachment`.