### PR TITLE
Add configration of EXTERNAL_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inteli OpenAPI service for interacting with the DSCP (Digital Supply-Chain Platf
 | :--------------------------- | :------: | :--------------------: | :----------------------------------------------------------------------------------- |
 | SERVICE_TYPE                 |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
 | PORT                         |    N     |          `80`          | The port for the API to listen on                                                    |
+| EXTERNAL_URL                 |    N     |                        | The url from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}/${API_MAJOR_VERSION}` |
 | LOG_LEVEL                    |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
 | API_VERSION                  |    N     | `package.json version` | API version                                                                          |
 | API_MAJOR_VERSION            |    N     |          `v1`          | API major version                                                                    |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Inteli OpenAPI service for interacting with the DSCP (Digital Supply-Chain Platf
 | :--------------------------- | :------: | :--------------------: | :----------------------------------------------------------------------------------- |
 | SERVICE_TYPE                 |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
 | PORT                         |    N     |          `80`          | The port for the API to listen on                                                    |
-| EXTERNAL_URL                 |    N     |                        | The url from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}/${API_MAJOR_VERSION}` |
+| EXTERNAL_ORIGIN              |    N     |                        | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
+| EXTERNAL_PATH_PREFIX         |    N     |                        | A path prefix from which this service is served |
 | LOG_LEVEL                    |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`] |
 | API_VERSION                  |    N     | `package.json version` | API version                                                                          |
 | API_MAJOR_VERSION            |    N     |          `v1`          | API major version                                                                    |

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -1,4 +1,10 @@
-const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_URL } = require('../env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_ORIGIN, EXTERNAL_PATH_PREFIX } = require('../env')
+
+let url = EXTERNAL_ORIGIN || `http://localhost:${PORT}`
+if (EXTERNAL_PATH_PREFIX) {
+  url = `${url}/${EXTERNAL_PATH_PREFIX}`
+}
+url = `${url}/${API_MAJOR_VERSION}`
 
 const securitySchemes =
   AUTH_TYPE === 'JWT'
@@ -21,7 +27,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url: EXTERNAL_URL || `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
+      url,
     },
   ],
   components: {

--- a/app/api-v1/api-doc.js
+++ b/app/api-v1/api-doc.js
@@ -1,4 +1,4 @@
-const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE } = require('../env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_URL } = require('../env')
 
 const securitySchemes =
   AUTH_TYPE === 'JWT'
@@ -21,7 +21,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url: `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
+      url: EXTERNAL_URL || `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
     },
   ],
   components: {

--- a/app/env.js
+++ b/app/env.js
@@ -41,6 +41,7 @@ const vars = envalid.cleanEnv(
     FILE_UPLOAD_SIZE_LIMIT_BYTES: envalid.num({ default: 1024 * 1024 * 100, devDefault: 1024 * 1024 * 10 }),
     IDENTITY_SERVICE_HOST: envalid.host({ devDefault: 'localhost' }),
     IDENTITY_SERVICE_PORT: envalid.port({ devDefault: 3002 }),
+    EXTERNAL_URL: envalid.str({ default: '' }),
   },
   {
     strict: true,

--- a/app/env.js
+++ b/app/env.js
@@ -41,7 +41,8 @@ const vars = envalid.cleanEnv(
     FILE_UPLOAD_SIZE_LIMIT_BYTES: envalid.num({ default: 1024 * 1024 * 100, devDefault: 1024 * 1024 * 10 }),
     IDENTITY_SERVICE_HOST: envalid.host({ devDefault: 'localhost' }),
     IDENTITY_SERVICE_PORT: envalid.port({ devDefault: 3002 }),
-    EXTERNAL_URL: envalid.str({ default: '' }),
+    EXTERNAL_ORIGIN: envalid.str({ default: '' }),
+    EXTERNAL_PATH_PREFIX: envalid.str({ default: '' }),
   },
   {
     strict: true,

--- a/app/server.js
+++ b/app/server.js
@@ -8,7 +8,14 @@ const multer = require('multer')
 const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
-const { PORT, API_VERSION, API_MAJOR_VERSION, FILE_UPLOAD_SIZE_LIMIT_BYTES, AUTH_TYPE, EXTERNAL_URL } = require('./env')
+const {
+  PORT,
+  API_VERSION,
+  API_MAJOR_VERSION,
+  FILE_UPLOAD_SIZE_LIMIT_BYTES,
+  AUTH_TYPE,
+  EXTERNAL_PATH_PREFIX,
+} = require('./env')
 const logger = require('./utils/Logger')
 const v1ApiDoc = require('./api-v1/api-doc')
 const v1DscpApiService = require('./api-v1/services/dscpApiService')
@@ -68,14 +75,18 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: EXTERNAL_URL ? `${EXTERNAL_URL}/api-docs` : `../api-docs`,
+          url: `${v1ApiDoc.servers[0].url}/api-docs`,
           name: 'Inteli API Service',
         },
       ],
     },
   }
 
-  app.use(`/${API_MAJOR_VERSION}/swagger`, swaggerUi.serve, swaggerUi.setup(null, options))
+  app.use(
+    EXTERNAL_PATH_PREFIX ? `/${EXTERNAL_PATH_PREFIX}/${API_MAJOR_VERSION}/swagger` : `/${API_MAJOR_VERSION}/swagger`,
+    swaggerUi.serve,
+    swaggerUi.setup(null, options)
+  )
   app.use(handleErrors)
 
   return { app }

--- a/app/server.js
+++ b/app/server.js
@@ -89,6 +89,12 @@ async function createHttpServer() {
   )
   app.use(handleErrors)
 
+  logger.trace('Registered Express routes: %s', {
+    toString: () => {
+      return JSON.stringify(app._router.stack.map(({ route }) => route && route.path).filter((p) => !!p))
+    },
+  })
+
   return { app }
 }
 

--- a/app/server.js
+++ b/app/server.js
@@ -8,7 +8,7 @@ const multer = require('multer')
 const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
-const { PORT, API_VERSION, API_MAJOR_VERSION, FILE_UPLOAD_SIZE_LIMIT_BYTES, AUTH_TYPE } = require('./env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, FILE_UPLOAD_SIZE_LIMIT_BYTES, AUTH_TYPE, EXTERNAL_URL } = require('./env')
 const logger = require('./utils/Logger')
 const v1ApiDoc = require('./api-v1/api-doc')
 const v1DscpApiService = require('./api-v1/services/dscpApiService')
@@ -68,7 +68,7 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: `http://localhost:${PORT}/${API_MAJOR_VERSION}/api-docs`,
+          url: EXTERNAL_URL ? `${EXTERNAL_URL}/api-docs` : `../api-docs`,
           name: 'Inteli API Service',
         },
       ],

--- a/helm/inteli-api/Chart.yaml
+++ b/helm/inteli-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-api
-appVersion: '1.29.0'
+appVersion: '1.29.1'
 description: A Helm chart for inteli-api
-version: '1.29.0'
+version: '1.29.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-api/templates/configmap.yaml
+++ b/helm/inteli-api/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "inteli-api.labels" . | nindent 4 }}
 data:
   port: {{ .Values.config.port | quote }}
+  {{- if .Values.config.externalUrl }}
+  externalUrl: {{ .Values.config.externalUrl }}
+  {{- end }}
   dscpApiHost: {{ .Values.config.dscpApiHost }}
   dscpApiPort: {{ .Values.config.dscpApiPort | quote }}
   logLevel: {{ .Values.config.logLevel }}

--- a/helm/inteli-api/templates/configmap.yaml
+++ b/helm/inteli-api/templates/configmap.yaml
@@ -6,8 +6,11 @@ metadata:
     {{- include "inteli-api.labels" . | nindent 4 }}
 data:
   port: {{ .Values.config.port | quote }}
-  {{- if .Values.config.externalUrl }}
-  externalUrl: {{ .Values.config.externalUrl }}
+  {{- if .Values.config.externalOrigin }}
+  externalOrigin: {{ .Values.config.externalOrigin }}
+  {{- end }}
+  {{- if .Values.config.externalPathPrefix }}
+  externalPathPrefix: {{ .Values.config.externalPathPrefix }}
   {{- end }}
   dscpApiHost: {{ .Values.config.dscpApiHost }}
   dscpApiPort: {{ .Values.config.dscpApiPort | quote }}

--- a/helm/inteli-api/templates/deployment.yaml
+++ b/helm/inteli-api/templates/deployment.yaml
@@ -71,12 +71,19 @@ spec:
                 configMapKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-config
                   key: port
-            {{- if .Values.config.externalUrl }}
-            - name: EXTERNAL_URL
+            {{- if .Values.config.externalOrigin }}
+            - name: EXTERNAL_ORIGIN
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-config
-                  key: externalUrl
+                  key: externalOrigin
+            {{- end }}
+            {{- if .Values.config.externalPathPrefix }}
+            - name: EXTERNAL_PATH_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "inteli-api.fullname" . }}-config
+                  key: externalPathPrefix
             {{- end }}
             - name: LOG_LEVEL
               valueFrom:

--- a/helm/inteli-api/templates/deployment.yaml
+++ b/helm/inteli-api/templates/deployment.yaml
@@ -71,6 +71,13 @@ spec:
                 configMapKeyRef:
                   name: {{ include "inteli-api.fullname" . }}-config
                   key: port
+            {{- if .Values.config.externalUrl }}
+            - name: EXTERNAL_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "inteli-api.fullname" . }}-config
+                  key: externalUrl
+            {{- end }}
             - name: LOG_LEVEL
               valueFrom:
                 configMapKeyRef:

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -1,6 +1,7 @@
 config:
   port: 80
-  # externalUrl: "http://localhost:3000/v3" # Overrides the server url in the openapi spec
+  # externalOrigin: "http://localhost:3000" # Overrides the server url in the openapi spec
+  # externalPathPrefix: "alice/inteli-api" # Path prefix to be applied to served API routes
   dscpApiHost: dscp-api
   dscpApiPort: 80
   logLevel: info

--- a/helm/inteli-api/values.yaml
+++ b/helm/inteli-api/values.yaml
@@ -1,5 +1,6 @@
 config:
   port: 80
+  # externalUrl: "http://localhost:3000/v3" # Overrides the server url in the openapi spec
   dscpApiHost: dscp-api
   dscpApiPort: 80
   logLevel: info
@@ -39,7 +40,7 @@ service:
 image:
   repository: digicatapult/inteli-api
   pullPolicy: IfNotPresent
-  tag: 'v1.29.0'
+  tag: 'v1.29.1'
   pullSecrets: []
 
 postgresql:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/inteli-api",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/inteli-api",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Insert repo description",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Adds the env EXTERNAL_URL which if provided will override the url field in the published openapi spec.
